### PR TITLE
chore: update implementation for _executeWithToken

### DIFF
--- a/packages/axelar-local-dev-cosmos/docker/agoric/docker-compose.yaml
+++ b/packages/axelar-local-dev-cosmos/docker/agoric/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   agoric:
-    image: ghcr.io/agoric/agoric-3-proposals:use-upgrade-19
+    image: ghcr.io/agoric/agoric-3-proposals:latest
     container_name: agoric
     entrypoint: /bin/bash -c "/root/private/bin/init_agoric.sh && exec ./start_agd.sh"
     volumes:


### PR DESCRIPTION
This PR updates the `_executeWithToken` function in the Factory contract to support executing incoming contract calls from Agoric. It also adds logic to prepay gas and send the response back to Agoric.