### PR TITLE
 feat: add deployment support for Base, Optimism, and Arbitrum Sepoli…

### DIFF
--- a/packages/axelar-local-dev-cosmos/hardhat.config.ts
+++ b/packages/axelar-local-dev-cosmos/hardhat.config.ts
@@ -13,10 +13,28 @@ const testnets = {
     chainId: 43113,
     accounts: [`0x${PRIVATE_KEY}`],
   },
-  sepolia: {
+  "eth-sepolia": {
     url: "https://ethereum-sepolia-rpc.publicnode.com",
     gasPrice: 20000000000, // 20 Gwei
     chainId: 11155111,
+    accounts: [`0x${PRIVATE_KEY}`],
+  },
+  "base-sepolia": {
+    // source: https://docs.base.org/base-chain/quickstart/connecting-to-base
+    url: "https://sepolia.base.org",
+    chainId: 84532,
+    accounts: [`0x${PRIVATE_KEY}`],
+  },
+  "opt-sepolia": {
+    // source: https://docs.optimism.io/superchain/networks#op-sepolia
+    url: "https://sepolia.optimism.io/",
+    chainId: 11155420,
+    accounts: [`0x${PRIVATE_KEY}`],
+  },
+  "arb-sepolia": {
+    // source: https://docs.arbitrum.io/build-decentralized-apps/reference/node-providers#arbitrum-public-rpc-endpoints
+    url: "https://sepolia-rollup.arbitrum.io/rpc",
+    chainId: 421614,
     accounts: [`0x${PRIVATE_KEY}`],
   },
 };

--- a/packages/axelar-local-dev-cosmos/scripts/deploy.sh
+++ b/packages/axelar-local-dev-cosmos/scripts/deploy.sh
@@ -2,8 +2,10 @@
 
 if [[ $# -eq 0 ]]; then
     echo "Usage: $0 <network>"
-    echo "Supported networks: avax, arb, sepolia, fuji, opt, pol"
-    exit 1
+    echo "Supported networks:"
+    echo "  Mainnets: avax, arb, opt, pol"
+    echo "  Testnets: eth-sepolia, fuji, base-sepolia, opt-sepolia, arb-sepolia"
+    exit 0
 fi
 
 network=$1
@@ -33,6 +35,7 @@ delete_deployments_folder() {
 # Mainnet: https://docs.axelar.dev/dev/reference/mainnet-contract-addresses/
 # Testnet: https://docs.axelar.dev/dev/reference/testnet-contract-addresses/
 case $network in
+# Mainnets
 avax)
     GATEWAY='0x5029C0EFf6C34351a0CEc334542cDb22c7928f78'
     GAS_SERVICE='0x2d5d7d31F671F86C782533cc367F14109a082712'
@@ -41,14 +44,6 @@ arb)
     GATEWAY='0xe432150cce91c13a887f7D836923d5597adD8E31'
     GAS_SERVICE='0x2d5d7d31F671F86C782533cc367F14109a082712'
     ;;
-sepolia)
-    GATEWAY='0xe432150cce91c13a887f7D836923d5597adD8E31'
-    GAS_SERVICE='0xbE406F0189A0B4cf3A05C286473D23791Dd44Cc6'
-    ;;
-fuji)
-    GATEWAY='0xC249632c2D40b9001FE907806902f63038B737Ab'
-    GAS_SERVICE='0xbE406F0189A0B4cf3A05C286473D23791Dd44Cc6'
-    ;;
 opt)
     GATEWAY='0xe432150cce91c13a887f7D836923d5597adD8E31'
     GAS_SERVICE='0x2d5d7d31F671F86C782533cc367F14109a082712'
@@ -56,6 +51,27 @@ opt)
 pol)
     GATEWAY='0x6f015F16De9fC8791b234eF68D486d2bF203FBA8'
     GAS_SERVICE='0x2d5d7d31F671F86C782533cc367F14109a082712'
+    ;;
+# Testnets
+eth-sepolia)
+    GATEWAY='0xe432150cce91c13a887f7D836923d5597adD8E31'
+    GAS_SERVICE='0xbE406F0189A0B4cf3A05C286473D23791Dd44Cc6'
+    ;;
+fuji)
+    GATEWAY='0xC249632c2D40b9001FE907806902f63038B737Ab'
+    GAS_SERVICE='0xbE406F0189A0B4cf3A05C286473D23791Dd44Cc6'
+    ;;
+base-sepolia)
+    GATEWAY='0xe432150cce91c13a887f7D836923d5597adD8E31'
+    GAS_SERVICE='0xbE406F0189A0B4cf3A05C286473D23791Dd44Cc6'
+    ;;
+opt-sepolia)
+    GATEWAY='0xe432150cce91c13a887f7D836923d5597adD8E31'
+    GAS_SERVICE='0xbE406F0189A0B4cf3A05C286473D23791Dd44Cc6'
+    ;;
+arb-sepolia)
+    GATEWAY='0xe1cE95479C84e9809269227C7F8524aE051Ae77a'
+    GAS_SERVICE='0xbE406F0189A0B4cf3A05C286473D23791Dd44Cc6'
     ;;
 *)
     echo "Invalid network specified"


### PR DESCRIPTION
  - Add Base Sepolia, OP Sepolia, and Arbitrum Sepolia testnet configs to `Hardhat` config
  - Rename `sepolia` to `eth-sepolia` for consistency
  - Update deploy script to support new testnets with respective gateway and gas service addresses
  - Organize deploy script networks by mainnet/testnet categories for better readability