### PR TITLE
feat: gasEstimator contract

### DIFF
--- a/packages/axelar-local-dev-cosmos/src/__tests__/contracts/GasEstimator.sol
+++ b/packages/axelar-local-dev-cosmos/src/__tests__/contracts/GasEstimator.sol
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.20;
+
+import {AxelarExecutable} from "@axelar-network/axelar-gmp-sdk-solidity/contracts/executable/AxelarExecutable.sol";
+import {IAxelarGasService} from "@axelar-network/axelar-gmp-sdk-solidity/contracts/interfaces/IAxelarGasService.sol";
+import {IERC20} from "@axelar-network/axelar-gmp-sdk-solidity/contracts/interfaces/IERC20.sol";
+import {StringToAddress, AddressToString} from "@axelar-network/axelar-gmp-sdk-solidity/contracts/libs/AddressString.sol";
+import {IAxelarGateway} from "@axelar-network/axelar-gmp-sdk-solidity/contracts/interfaces/IAxelarGateway.sol";
+import {Ownable} from "./Ownable.sol";
+
+struct CallResult {
+    bool success;
+    bytes result;
+}
+
+struct AgoricResponse {
+    // false if this is a smart wallet creation, true if it's a contract call
+    bool isContractCallResult;
+    CallResult[] data;
+}
+
+struct ContractCalls {
+    address target;
+    bytes data;
+}
+
+struct CallMessage {
+    string id;
+    ContractCalls[] calls;
+}
+
+contract Wallet is AxelarExecutable, Ownable {
+    IAxelarGasService public gasService;
+
+    event MulticallExecuted(string indexed id, CallResult[] results);
+    event Received(address indexed sender, uint256 amount);
+
+    constructor(
+        address gateway_,
+        address gasReceiver_,
+        string memory owner_
+    ) AxelarExecutable(gateway_) Ownable(owner_) {
+        gasService = IAxelarGasService(gasReceiver_);
+    }
+
+    function _multicall(bytes calldata payload) internal {
+        CallMessage memory callMessage = abi.decode(payload, (CallMessage));
+        ContractCalls[] memory calls = callMessage.calls;
+
+        CallResult[] memory results = new CallResult[](calls.length);
+
+        for (uint256 i = 0; i < calls.length; i++) {
+            (bool success, bytes memory result) = calls[i].target.call(
+                calls[i].data
+            );
+            require(success, "Contract call failed");
+            results[i] = CallResult(success, result);
+        }
+
+        emit MulticallExecuted(callMessage.id, results);
+    }
+
+    function _execute(
+        string calldata /*sourceChain*/,
+        string calldata sourceAddress,
+        bytes calldata payload
+    ) internal override onlyOwner(sourceAddress) {
+        _multicall(payload);
+    }
+
+    function _executeWithToken(
+        string calldata /*sourceChain*/,
+        string calldata /*sourceAddress*/,
+        bytes calldata payload,
+        string calldata /*tokenSymbol*/,
+        uint256 /*amount*/
+    ) internal override onlyOwner(sourceAddress) {
+        _multicall(payload);
+    }
+
+    receive() external payable {
+        emit Received(msg.sender, msg.value);
+    }
+
+    fallback() external payable {
+        emit Received(msg.sender, msg.value);
+    }
+}
+
+contract GasEstimator is AxelarExecutable, Ownable {
+    using StringToAddress for string;
+    using AddressToString for address;
+
+    address _gateway;
+    IAxelarGasService public immutable gasService;
+
+    event SmartWalletCreated(
+        address indexed wallet,
+        string owner,
+        string sourceChain,
+        string sourceAddress
+    );
+    event CrossChainCallSent(
+        string destinationChain,
+        string destinationAddress,
+        bytes payload
+    );
+    event Received(address indexed sender, uint256 amount);
+    event MulticallExecuted(string indexed id, CallResult[] results);
+
+
+    constructor(
+        address gateway_,
+        address gasReceiver_,
+        string memory owner_
+    ) AxelarExecutable(gateway_) Ownable(owner_) {
+        gasService = IAxelarGasService(gasReceiver_);
+        _gateway = gateway_;
+    }
+
+    function _createSmartWallet(string memory owner) internal returns (address) {
+        address newWallet = address(
+            new Wallet(_gateway, address(gasService), owner)
+        );
+        return newWallet;
+    }
+
+    function _verification(
+        bytes32 commandId,
+        string calldata sourceChain,
+        string calldata sourceAddress,
+        bytes calldata payload
+    ) internal {
+        bytes32 payloadHash = keccak256(payload);
+        IAxelarGateway(_gateway).validateContractCall(commandId, sourceChain, sourceAddress, payloadHash);
+    }
+
+    function executeFactory(
+        bytes32 commandId,
+        string calldata sourceChain,
+        string calldata sourceAddress,
+        bytes calldata payload
+    ) public {
+        _verification(commandId, sourceChain, sourceAddress, payload);
+        _ef(sourceChain, sourceAddress, payload);
+    }
+
+    function _ef(
+        string calldata sourceChain,
+        string calldata sourceAddress,
+        bytes calldata payload
+    ) internal {
+        uint256 gasAmount = abi.decode(payload, (uint256));
+        address smartWalletAddress = _createSmartWallet(sourceAddress);
+        emit SmartWalletCreated(
+            smartWalletAddress,
+            sourceAddress,
+            sourceChain,
+            sourceAddress
+        );
+        CallResult[] memory results = new CallResult[](1);
+
+        results[0] = CallResult(true, abi.encode(smartWalletAddress));
+
+        bytes memory msgPayload = abi.encodePacked(
+            bytes4(0x00000000),
+            abi.encode(AgoricResponse(false, results))
+        );
+        _send(sourceChain, sourceAddress, msgPayload, gasAmount);
+    }
+
+    function _send(
+        string calldata destinationChain,
+        string calldata destinationAddress,
+        bytes memory payload,
+        uint256 gasAmount
+    ) internal {
+        gasService.payNativeGasForContractCall{value: gasAmount}(
+            address(this),
+            destinationChain,
+            destinationAddress,
+            payload,
+            address(this)
+        );
+
+        gateway.callContract(destinationChain, destinationAddress, payload);
+        emit CrossChainCallSent(destinationChain, destinationAddress, payload);
+    }
+
+
+    function _multicall(bytes calldata payload) internal {
+        CallMessage memory callMessage = abi.decode(payload, (CallMessage));
+        ContractCalls[] memory calls = callMessage.calls;
+
+        CallResult[] memory results = new CallResult[](calls.length);
+
+        for (uint256 i = 0; i < calls.length; i++) {
+            (bool success, bytes memory result) = calls[i].target.call(
+                calls[i].data
+            );
+            require(success, "Contract call failed");
+            results[i] = CallResult(success, result);
+        }
+
+        emit MulticallExecuted(callMessage.id, results);
+    }
+
+    function executeWallet(
+        bytes32 commandId,
+        string calldata sourceChain,
+        string calldata sourceAddress,
+        bytes calldata payload
+    ) public {
+        _verification(commandId, sourceChain, sourceAddress, payload);
+        _ew(sourceChain, sourceAddress, payload);
+    }
+    
+    function _ew (
+        string calldata /*sourceChain*/,
+        string calldata sourceAddress,
+        bytes calldata payload
+    ) internal onlyOwner(sourceAddress) {
+        _multicall(payload);
+    }
+
+    receive() external payable {
+        emit Received(msg.sender, msg.value);
+    }
+
+    fallback() external payable {
+        emit Received(msg.sender, msg.value);
+    }
+}


### PR DESCRIPTION
This PR introduces a new GasEstimator.sol contract

the purpose of this contract is to act as a mock of the real Wallet and Factory contracts, without any of the restrictions in execution that we have in the real ones.

This allows us to use `estimateGas` apis on this contract without the contract reverting in case of axelar verification checks.

the GasEstimator contract has two external functions. `estimateWallet` and `estimateFactory` both mimick the flow of their respective contracts but without any checks so `estimateGas` can work properly