### PR TITLE
chore: add script to verify wallet contracts for debugging

### DIFF
--- a/packages/axelar-local-dev-cosmos/package.json
+++ b/packages/axelar-local-dev-cosmos/package.json
@@ -25,7 +25,8 @@
     "testWallet": "ts-node scripts/runner.ts testWallet",
     "testFactory": "ts-node scripts/runner.ts testFactory",
     "test:proxy": "hardhat test src/__tests__/Factory.spec.ts",
-    "coverage:proxy": "npx hardhat coverage --testfiles src/__tests__/Factory.spec.ts"
+    "coverage:proxy": "npx hardhat coverage --testfiles src/__tests__/Factory.spec.ts",
+    "verify": "./scripts/verify.sh"
   },
   "dependencies": {
     "@axelar-network/axelar-local-dev": "^2.3.2",

--- a/packages/axelar-local-dev-cosmos/scripts/deploy.sh
+++ b/packages/axelar-local-dev-cosmos/scripts/deploy.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Get the directory of the script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/network-config.sh"
+
 if [[ $# -eq 0 ]]; then
     echo "Usage: $0 <network>"
     echo "Supported networks:"
@@ -30,54 +34,7 @@ delete_deployments_folder() {
     fi
 }
 
-
-# Mainnet and testnet contract addresses sourced from:
-# Mainnet: https://docs.axelar.dev/dev/reference/mainnet-contract-addresses/
-# Testnet: https://docs.axelar.dev/dev/reference/testnet-contract-addresses/
-case $network in
-# Mainnets
-avax)
-    GATEWAY='0x5029C0EFf6C34351a0CEc334542cDb22c7928f78'
-    GAS_SERVICE='0x2d5d7d31F671F86C782533cc367F14109a082712'
-    ;;
-arb)
-    GATEWAY='0xe432150cce91c13a887f7D836923d5597adD8E31'
-    GAS_SERVICE='0x2d5d7d31F671F86C782533cc367F14109a082712'
-    ;;
-opt)
-    GATEWAY='0xe432150cce91c13a887f7D836923d5597adD8E31'
-    GAS_SERVICE='0x2d5d7d31F671F86C782533cc367F14109a082712'
-    ;;
-pol)
-    GATEWAY='0x6f015F16De9fC8791b234eF68D486d2bF203FBA8'
-    GAS_SERVICE='0x2d5d7d31F671F86C782533cc367F14109a082712'
-    ;;
-# Testnets
-eth-sepolia)
-    GATEWAY='0xe432150cce91c13a887f7D836923d5597adD8E31'
-    GAS_SERVICE='0xbE406F0189A0B4cf3A05C286473D23791Dd44Cc6'
-    ;;
-fuji)
-    GATEWAY='0xC249632c2D40b9001FE907806902f63038B737Ab'
-    GAS_SERVICE='0xbE406F0189A0B4cf3A05C286473D23791Dd44Cc6'
-    ;;
-base-sepolia)
-    GATEWAY='0xe432150cce91c13a887f7D836923d5597adD8E31'
-    GAS_SERVICE='0xbE406F0189A0B4cf3A05C286473D23791Dd44Cc6'
-    ;;
-opt-sepolia)
-    GATEWAY='0xe432150cce91c13a887f7D836923d5597adD8E31'
-    GAS_SERVICE='0xbE406F0189A0B4cf3A05C286473D23791Dd44Cc6'
-    ;;
-arb-sepolia)
-    GATEWAY='0xe1cE95479C84e9809269227C7F8524aE051Ae77a'
-    GAS_SERVICE='0xbE406F0189A0B4cf3A05C286473D23791Dd44Cc6'
-    ;;
-*)
-    echo "Invalid network specified"
-    exit 1
-    ;;
-esac
+get_network_config "$network"
 
 delete_deployments_folder "ignition/deployments"
 deploy_contract "./ignition/modules/deployFactory.ts" "$GATEWAY" "$GAS_SERVICE"

--- a/packages/axelar-local-dev-cosmos/scripts/network-config.sh
+++ b/packages/axelar-local-dev-cosmos/scripts/network-config.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Mainnet and testnet contract addresses sourced from:
+# Mainnet: https://docs.axelar.dev/dev/reference/mainnet-contract-addresses/
+# Testnet: https://docs.axelar.dev/dev/reference/testnet-contract-addresses/
+get_network_config() {
+    local network=$1
+
+    case $network in
+    # Mainnets
+    avax)
+        GATEWAY='0x5029C0EFf6C34351a0CEc334542cDb22c7928f78'
+        GAS_SERVICE='0x2d5d7d31F671F86C782533cc367F14109a082712'
+        ;;
+    arb)
+        GATEWAY='0xe432150cce91c13a887f7D836923d5597adD8E31'
+        GAS_SERVICE='0x2d5d7d31F671F86C782533cc367F14109a082712'
+        ;;
+    opt)
+        GATEWAY='0xe432150cce91c13a887f7D836923d5597adD8E31'
+        GAS_SERVICE='0x2d5d7d31F671F86C782533cc367F14109a082712'
+        ;;
+    pol)
+        GATEWAY='0x6f015F16De9fC8791b234eF68D486d2bF203FBA8'
+        GAS_SERVICE='0x2d5d7d31F671F86C782533cc367F14109a082712'
+        ;;
+    # Testnets
+    eth-sepolia)
+        GATEWAY='0xe432150cce91c13a887f7D836923d5597adD8E31'
+        GAS_SERVICE='0xbE406F0189A0B4cf3A05C286473D23791Dd44Cc6'
+        ;;
+    fuji)
+        GATEWAY='0xC249632c2D40b9001FE907806902f63038B737Ab'
+        GAS_SERVICE='0xbE406F0189A0B4cf3A05C286473D23791Dd44Cc6'
+        ;;
+    base-sepolia)
+        GATEWAY='0xe432150cce91c13a887f7D836923d5597adD8E31'
+        GAS_SERVICE='0xbE406F0189A0B4cf3A05C286473D23791Dd44Cc6'
+        ;;
+    opt-sepolia)
+        GATEWAY='0xe432150cce91c13a887f7D836923d5597adD8E31'
+        GAS_SERVICE='0xbE406F0189A0B4cf3A05C286473D23791Dd44Cc6'
+        ;;
+    arb-sepolia)
+        GATEWAY='0xe1cE95479C84e9809269227C7F8524aE051Ae77a'
+        GAS_SERVICE='0xbE406F0189A0B4cf3A05C286473D23791Dd44Cc6'
+        ;;
+    *)
+        echo "Invalid network specified"
+        exit 1
+        ;;
+    esac
+}

--- a/packages/axelar-local-dev-cosmos/scripts/verify.sh
+++ b/packages/axelar-local-dev-cosmos/scripts/verify.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# This script is used to verify any Wallet contract
+# By verifying a wallet contract, we can attach its source code to a public
+# explorer (e.g snowtrace) which can be used later by a debugger (e.g tenderly) to make
+# a human readable stack trace. This is helpful for figuring out why a 
+# certain contract call failed.
+#
+# For verification we will need:
+# 1. The address of the contract
+# 2. The owner address (an agoric bech32 address) of the contract
+# the second argument can be found by decoding the `SmartWalletCreated`
+# event of the tx that created the contract in the first place
+# e.g https://testnet.snowtrace.io/tx/0x0de743f69831ae404925307d1c25af941c276ccffdc6713db886ae4ec688f1e0/eventlog?chainid=43113
+
+
+# Get the directory of the script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/network-config.sh"
+
+if [[ $# -lt 3 ]]; then
+    echo "Usage: $0 <network> <wallet_address> <owner>"
+    echo "Supported networks:"
+    echo "  Mainnets: avax, arb, opt, pol"
+    echo "  Testnets: eth-sepolia, fuji, base-sepolia, opt-sepolia, arb-sepolia"
+    echo ""
+    echo "Example:"
+    echo "  $0 fuji 0x123... agoric1..."
+    exit 0
+fi
+
+network=$1
+wallet_address=$2
+owner=$3
+
+get_network_config "$network"
+
+echo "Verifying Wallet contract at: $wallet_address"
+echo "Network: $network"
+echo "Gateway: $GATEWAY"
+echo "Gas Service: $GAS_SERVICE"
+echo "Owner: $owner"
+
+npx hardhat verify --network "$network" \
+    "$wallet_address" \
+    "$GATEWAY" \
+    "$GAS_SERVICE" \
+    "$owner" \
+    --contract "src/__tests__/contracts/Factory.sol:Wallet"


### PR DESCRIPTION
adds script that can be used to verify any `Wallet` contract:
```

> @axelar-network/axelar-local-dev-cosmos@2.3.2 verify
> ./scripts/verify.sh fuji 0xefcdd2e0237c6894dee04855e311d0dcdd1bb244 agoric1rwwley550k9mmk6uq6mm6z4ud

Verifying Wallet contract at: 0xefcdd2e0237c6894dee04855e311d0dcdd1bb244
Network: fuji
Gateway: 0xC249632c2D40b9001FE907806902f63038B737Ab
Gas Service: 0xbE406F0189A0B4cf3A05C286473D23791Dd44Cc6
Owner: agoric1rwwley550k9mmk6uq6mm6z4ud
[INFO] Sourcify Verification Skipped: Sourcify verification is currently disabled. To enable it, add the following entry to your Hardhat configuration:

sourcify: {
  enabled: true
}

Or set 'enabled' to false to hide this message.

For more information, visit https://hardhat.org/hardhat-runner/plugins/nomicfoundation-hardhat-verify#verifying-on-sourcify
[WARNING] Network and explorer-specific api keys are deprecated in favour of the new Etherscan v2 api. Support for v1 is expected to end by May 31st, 2025. To migrate, please specify a single Etherscan.io api key the apiKey config value.
Successfully submitted source code for contract
src/__tests__/contracts/Factory.sol:Wallet at 0xefcdd2e0237c6894dee04855e311d0dcdd1bb244
for verification on the block explorer. Waiting for verification result...

Successfully verified contract Wallet on the block explorer.
https://testnet.snowtrace.io/address/0xefcdd2e0237c6894dee04855e311d0dcdd1bb244#code
```
this results in a verified contract which can be debugged using tenderly:
https://www.tdly.co/tx/0x1df09c9d1b2e178a9d0999fd22082d6bb1303f2c1c986c7e5832c292c4b69160