### PR TITLE
chore: minor improvements in event emission

### DIFF
--- a/packages/axelar-local-dev-cosmos/src/__tests__/contracts/Factory.sol
+++ b/packages/axelar-local-dev-cosmos/src/__tests__/contracts/Factory.sol
@@ -59,6 +59,10 @@ contract Wallet is AxelarExecutable, Ownable {
         for (uint256 i = 0; i < len; ) {
             (bool success, ) = calls[i].target.call(calls[i].data);
 
+            if (!success) {
+                revert ContractCallFailed(callMessage.id, i);
+            }
+
             emit CallStatus(
                 callMessage.id,
                 i,
@@ -66,10 +70,6 @@ contract Wallet is AxelarExecutable, Ownable {
                 bytes4(calls[i].data),
                 success
             );
-
-            if (!success) {
-                revert ContractCallFailed(callMessage.id, i);
-            }
 
             unchecked {
                 ++i;


### PR DESCRIPTION
- Removes emission of `MultiCallStatus` upon a tx failure. As the event is reverted as well on tx reversion. 
- Emits `CallStatus` event right after checking for tx success status. 