### PR TITLE
build: updated axelar-gmp-sdk-solidity version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26471,7 +26471,7 @@
         "@types/chai": "^4.2.0",
         "@types/mocha": "^10.0.10",
         "@types/node-fetch": "^2.6.5",
-        "@updated-axelar-network/axelar-gmp-sdk-solidity": "npm:@axelar-network/axelar-gmp-sdk-solidity@^6.0.4",
+        "@updated-axelar-network/axelar-gmp-sdk-solidity": "npm:@axelar-network/axelar-gmp-sdk-solidity@^6.0.6",
         "chai-as-promised": "^7.1.2",
         "dotenv": "^16.5.0",
         "ethers": "^5.6.5",

--- a/packages/axelar-local-dev-cosmos/package.json
+++ b/packages/axelar-local-dev-cosmos/package.json
@@ -63,7 +63,7 @@
     "@types/chai": "^4.2.0",
     "@types/mocha": "^10.0.10",
     "@types/node-fetch": "^2.6.5",
-    "@updated-axelar-network/axelar-gmp-sdk-solidity": "npm:@axelar-network/axelar-gmp-sdk-solidity@^6.0.4",
+    "@updated-axelar-network/axelar-gmp-sdk-solidity": "npm:@axelar-network/axelar-gmp-sdk-solidity@^6.0.6",
     "chai-as-promised": "^7.1.2",
     "dotenv": "^16.5.0",
     "ethers": "^5.6.5",

--- a/packages/axelar-local-dev-cosmos/src/__tests__/contracts/Factory.sol
+++ b/packages/axelar-local-dev-cosmos/src/__tests__/contracts/Factory.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.20;
 
-import {AxelarExecutable} from "@axelar-network/axelar-gmp-sdk-solidity/contracts/executable/AxelarExecutable.sol";
-import {IAxelarGasService} from "@axelar-network/axelar-gmp-sdk-solidity/contracts/interfaces/IAxelarGasService.sol";
-import {IERC20} from "@axelar-network/axelar-gmp-sdk-solidity/contracts/interfaces/IERC20.sol";
-import {StringToAddress, AddressToString} from "@axelar-network/axelar-gmp-sdk-solidity/contracts/libs/AddressString.sol";
+import {AxelarExecutable} from "@updated-axelar-network/axelar-gmp-sdk-solidity/contracts/executable/AxelarExecutable.sol";
+import {IAxelarGasService} from "@updated-axelar-network/axelar-gmp-sdk-solidity/contracts/interfaces/IAxelarGasService.sol";
+import {IERC20} from "@updated-axelar-network/axelar-gmp-sdk-solidity/contracts/interfaces/IERC20.sol";
+import {StringToAddress, AddressToString} from "@updated-axelar-network/axelar-gmp-sdk-solidity/contracts/libs/AddressString.sol";
 import {Ownable} from "./Ownable.sol";
 
 struct CallResult {
@@ -80,6 +80,7 @@ contract Wallet is AxelarExecutable, Ownable {
     }
 
     function _execute(
+        bytes32 /*commandId*/,
         string calldata /*sourceChain*/,
         string calldata sourceAddress,
         bytes calldata payload
@@ -134,6 +135,7 @@ contract Factory is AxelarExecutable {
     }
 
     function _execute(
+        bytes32 /*commandId*/,
         string calldata sourceChain,
         string calldata sourceAddress,
         bytes calldata payload
@@ -171,7 +173,7 @@ contract Factory is AxelarExecutable {
             address(this)
         );
 
-        gateway.callContract(destinationChain, destinationAddress, payload);
+        gateway().callContract(destinationChain, destinationAddress, payload);
         emit CrossChainCallSent(destinationChain, destinationAddress, payload);
     }
 

--- a/packages/axelar-local-dev-cosmos/src/__tests__/contracts/SendReceive.sol
+++ b/packages/axelar-local-dev-cosmos/src/__tests__/contracts/SendReceive.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.9;
 
-import {AxelarExecutable} from "@axelar-network/axelar-gmp-sdk-solidity/contracts/executable/AxelarExecutable.sol";
-import {IAxelarGateway} from "@axelar-network/axelar-gmp-sdk-solidity/contracts/interfaces/IAxelarGateway.sol";
-import {IAxelarGasService} from "@axelar-network/axelar-gmp-sdk-solidity/contracts/interfaces/IAxelarGasService.sol";
-import {StringToAddress, AddressToString} from "@axelar-network/axelar-gmp-sdk-solidity/contracts/libs/AddressString.sol";
+import {AxelarExecutable} from "@updated-axelar-network/axelar-gmp-sdk-solidity/contracts/executable/AxelarExecutable.sol";
+import {IAxelarGateway} from "@updated-axelar-network/axelar-gmp-sdk-solidity/contracts/interfaces/IAxelarGateway.sol";
+import {IAxelarGasService} from "@updated-axelar-network/axelar-gmp-sdk-solidity/contracts/interfaces/IAxelarGasService.sol";
+import {StringToAddress, AddressToString} from "@updated-axelar-network/axelar-gmp-sdk-solidity/contracts/libs/AddressString.sol";
 
 contract SendReceive is AxelarExecutable {
     using StringToAddress for string;
@@ -51,7 +51,7 @@ contract SendReceive is AxelarExecutable {
         );
 
         // 3. Make GMP call
-        gateway.callContract(destinationChain, destinationAddress, payload);
+        gateway().callContract(destinationChain, destinationAddress, payload);
     }
 
     function _encodePayloadToCosmWasm(
@@ -94,6 +94,7 @@ contract SendReceive is AxelarExecutable {
     }
 
     function _execute(
+        bytes32 /*commandId*/,
         string calldata /*sourceChain*/,
         string calldata /*sourceAddress*/,
         bytes calldata payload


### PR DESCRIPTION
closes: #33 
follow up to #32 

uses an alias for the updated `@axelar-network/axelar-gmp-sdk-solidity` package since there are conflicts if i update the old version