### PR TITLE
chore: delegate RemoteAccount ownership through factory for O(1) router migration

### DIFF
--- a/.github/workflows/deploy-contracts.yml
+++ b/.github/workflows/deploy-contracts.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/deploy-contracts.yml
+++ b/.github/workflows/deploy-contracts.yml
@@ -28,8 +28,8 @@ on:
       REMOTE_ACCOUNT_FACTORY:
         description: Remote account factory address (required for portfolioRouter)
         required: false
-      OWNER_AUTHORITY:
-        description: Owner authority address (required for portfolioRouter)
+      VETTING_AUTHORITY:
+        description: Vetting authority address (required for remoteAccountFactory)
         required: false
       ALL_CHAINS:
         description: Deploy to all chains
@@ -88,15 +88,13 @@ jobs:
         env:
           CONTRACT_OPTION: ${{ github.event.inputs.CONTRACT_OPTION }}
           REMOTE_ACCOUNT_FACTORY: ${{ github.event.inputs.REMOTE_ACCOUNT_FACTORY }}
-          OWNER_AUTHORITY: ${{ github.event.inputs.OWNER_AUTHORITY }}
+          VETTING_AUTHORITY: ${{ github.event.inputs.VETTING_AUTHORITY }}
         run: |
-          if [ "$CONTRACT_OPTION" = "portfolioRouter" ]; then
-            if [ -z "$REMOTE_ACCOUNT_FACTORY" ]; then
-              echo "REMOTE_ACCOUNT_FACTORY is required for portfolioRouter" && exit 1
-            fi
-            if [ -z "$OWNER_AUTHORITY" ]; then
-              echo "OWNER_AUTHORITY is required for portfolioRouter" && exit 1
-            fi
+          if [ "$CONTRACT_OPTION" = "portfolioRouter" ] && [ -z "$REMOTE_ACCOUNT_FACTORY" ]; then
+            echo "REMOTE_ACCOUNT_FACTORY is required for portfolioRouter" && exit 1
+          fi
+          if [ "$CONTRACT_OPTION" = "remoteAccountFactory" ] && [ -z "$VETTING_AUTHORITY" ]; then
+            echo "VETTING_AUTHORITY is required for remoteAccountFactory" && exit 1
           fi
 
       - name: Build chain list
@@ -150,7 +148,7 @@ jobs:
           OWNER_TYPE: ${{ github.event.inputs.OWNER_TYPE }}
           PARALLEL: ${{ github.event.inputs.PARALLEL }}
           REMOTE_ACCOUNT_FACTORY: ${{ github.event.inputs.REMOTE_ACCOUNT_FACTORY }}
-          OWNER_AUTHORITY: ${{ github.event.inputs.OWNER_AUTHORITY }}
+          VETTING_AUTHORITY: ${{ github.event.inputs.VETTING_AUTHORITY }}
           # Testnet: `0x15626280BF6a502b2F7f01944Ca23774567Cd56C` is the
           # address corresponding to the PRIVATE_KEY below.
           # Use https://cloud.google.com/application/web3/faucet/ethereum/sepolia

--- a/integration/deploy-all-chains.ts
+++ b/integration/deploy-all-chains.ts
@@ -486,9 +486,11 @@ Supported Chains:
 
 Note: Nonces are automatically checked and synchronized if they differ across chains.
 
+Environment Variables (for remoteAccountFactory):
+  VETTING_AUTHORITY            Required: Address authorized to vet new routers
+
 Environment Variables (for portfolioRouter):
   REMOTE_ACCOUNT_FACTORY       Required: Address of the deployed RemoteAccountFactory contract
-  OWNER_AUTHORITY              Required: Address authorized to designate router replacement
 
 Examples:
   # Deploy factory to all chains sequentially
@@ -507,10 +509,10 @@ Examples:
   yarn deploy:all -c depositFactory -o ymax1 --stop-on-error
 
   # Deploy remoteAccountFactory to testnets
-  yarn deploy:all -c remoteAccountFactory --testnet
+  VETTING_AUTHORITY=0x... yarn deploy:all -c remoteAccountFactory --testnet
 
   # Deploy RemoteAccountAxelarRouter
-  REMOTE_ACCOUNT_FACTORY=0x... OWNER_AUTHORITY=0x... yarn deploy:all -c portfolioRouter --testnet
+  REMOTE_ACCOUNT_FACTORY=0x... yarn deploy:all -c portfolioRouter --testnet
 `);
 };
 

--- a/packages/axelar-local-dev-cosmos/docs/DEPLOYMENT.md
+++ b/packages/axelar-local-dev-cosmos/docs/DEPLOYMENT.md
@@ -54,22 +54,30 @@ Deploy contracts in this order due to dependencies:
 
 ## Deploying RemoteAccountFactory
 
-`RemoteAccountFactory` requires principal CAIP2 and account constructor arguments to identify the controlling portfolio contract.
+`RemoteAccountFactory` requires principal CAIP2 and account constructor arguments to identify the controlling portfolio contract, as well as the address for a vetting authority
+
+The following environment variables are required:
+
+| Variable            | Required | Description                           |
+| ------------------- | -------- | ------------------------------------- |
+| `VETTING_AUTHORITY` | Yes      | Address authorized to vet new routers |
 
 ### Single Chain
 
 ```bash
 cd packages/axelar-local-dev-cosmos
-./scripts/deploy.sh <network> remoteAccountFactory [owner_type]
+VETTING_AUTHORITY=0x... ./scripts/deploy.sh <network> remoteAccountFactory [owner_type]
 ```
 
 Example:
 
 ```bash
 # Deploy with ymax0 principal (default)
+VETTING_AUTHORITY=0xabcd1234567890abcdef1234567890abcdef5678 \
 ./scripts/deploy.sh eth-sepolia remoteAccountFactory
 
 # Deploy with ymax1 principal
+VETTING_AUTHORITY=0xabcd1234567890abcdef1234567890abcdef5678 \
 ./scripts/deploy.sh eth-sepolia remoteAccountFactory ymax1
 ```
 
@@ -77,12 +85,15 @@ Example:
 
 ```bash
 # All testnets
+VETTING_AUTHORITY=0x... \
 npm run deploy:all -- -c remoteAccountFactory --testnet
 
 # All mainnets
+VETTING_AUTHORITY=0x... \
 npm run deploy:all -- -c remoteAccountFactory --mainnet
 
 # Specific chains
+VETTING_AUTHORITY=0x... \
 npm run deploy:all -- -c remoteAccountFactory --chains eth-sepolia,fuji,base-sepolia
 ```
 
@@ -93,23 +104,22 @@ npm run deploy:all -- -c remoteAccountFactory --chains eth-sepolia,fuji,base-sep
 | Variable                 | Required | Description                                           |
 | ------------------------ | -------- | ----------------------------------------------------- |
 | `REMOTE_ACCOUNT_FACTORY` | Yes      | Address of the deployed RemoteAccountFactory contract |
-| `OWNER_AUTHORITY`        | Yes      | Address authorized to designate router replacement    |
 
-**Note:** Factory ownership is automatically transferred to the router during deployment.
+**Note:** If the deployer is the same as the factory vetting authority, the new router is
+automatically vetted during deployment (and enabled if the initial router).
 
 ### Single Chain
 
 ```bash
 cd packages/axelar-local-dev-cosmos
 
-REMOTE_ACCOUNT_FACTORY=0x... OWNER_AUTHORITY=0x... ./scripts/deploy.sh <network> portfolioRouter
+REMOTE_ACCOUNT_FACTORY=0x... ./scripts/deploy.sh <network> portfolioRouter
 ```
 
 Example:
 
 ```bash
 REMOTE_ACCOUNT_FACTORY=0x1234567890abcdef1234567890abcdef12345678 \
-OWNER_AUTHORITY=0xabcd1234567890abcdef1234567890abcdef5678 \
 ./scripts/deploy.sh eth-sepolia portfolioRouter
 ```
 
@@ -117,14 +127,14 @@ OWNER_AUTHORITY=0xabcd1234567890abcdef1234567890abcdef5678 \
 
 ```bash
 # All testnets
-REMOTE_ACCOUNT_FACTORY=0x... OWNER_AUTHORITY=0x... \
+REMOTE_ACCOUNT_FACTORY=0x... \
 npm run deploy:all -- -c portfolioRouter --testnet
 
 # All mainnets
-REMOTE_ACCOUNT_FACTORY=0x... OWNER_AUTHORITY=0x... \
+REMOTE_ACCOUNT_FACTORY=0x... \
 npm run deploy:all -- -c portfolioRouter --mainnet
 
 # Specific chains
-REMOTE_ACCOUNT_FACTORY=0x... OWNER_AUTHORITY=0x... \
+REMOTE_ACCOUNT_FACTORY=0x... \
 npm run deploy:all -- -c portfolioRouter --chains eth-sepolia,fuji
 ```

--- a/packages/axelar-local-dev-cosmos/hardhat.config.ts
+++ b/packages/axelar-local-dev-cosmos/hardhat.config.ts
@@ -1,4 +1,5 @@
 import "@nomicfoundation/hardhat-toolbox";
+import "@nomicfoundation/hardhat-ignition-ethers";
 import { config as envConfig } from "dotenv";
 import { HardhatUserConfig } from "hardhat/config";
 

--- a/packages/axelar-local-dev-cosmos/ignition/modules/deployPortfolioRouter.ts
+++ b/packages/axelar-local-dev-cosmos/ignition/modules/deployPortfolioRouter.ts
@@ -3,30 +3,17 @@ import { config } from 'dotenv';
 
 config();
 
-const {
-    GATEWAY_CONTRACT,
-    AXELAR_SOURCE_CHAIN,
-    FACTORY_CONTRACT,
-    PERMIT2_CONTRACT,
-    OWNER_AUTHORITY,
-} = process.env;
+const { GATEWAY_CONTRACT, AXELAR_SOURCE_CHAIN, FACTORY_CONTRACT, PERMIT2_CONTRACT } = process.env;
 
 console.log('Deploying RemoteAccountAxelarRouter with:');
 console.log('  Gateway:', GATEWAY_CONTRACT);
 console.log('  Axelar Source Chain:', AXELAR_SOURCE_CHAIN);
 console.log('  Factory:', FACTORY_CONTRACT);
 console.log('  Permit2:', PERMIT2_CONTRACT);
-console.log('  Owner Authority:', OWNER_AUTHORITY);
 
-if (
-    !GATEWAY_CONTRACT ||
-    !AXELAR_SOURCE_CHAIN ||
-    !FACTORY_CONTRACT ||
-    !PERMIT2_CONTRACT ||
-    !OWNER_AUTHORITY
-) {
+if (!GATEWAY_CONTRACT || !AXELAR_SOURCE_CHAIN || !FACTORY_CONTRACT || !PERMIT2_CONTRACT) {
     throw new Error(
-        'Missing required env vars: GATEWAY_CONTRACT, AXELAR_SOURCE_CHAIN, FACTORY_CONTRACT, PERMIT2_CONTRACT, or OWNER_AUTHORITY',
+        'Missing required env vars: GATEWAY_CONTRACT, AXELAR_SOURCE_CHAIN, FACTORY_CONTRACT, or PERMIT2_CONTRACT',
     );
 }
 
@@ -35,21 +22,13 @@ export default buildModule('RemoteAccountAxelarRouterModule', (m) => {
     const axelarSourceChain = m.getParameter('axelarSourceChain_', AXELAR_SOURCE_CHAIN);
     const factoryAddress = m.getParameter('factory_', FACTORY_CONTRACT);
     const permit2 = m.getParameter('permit2_', PERMIT2_CONTRACT);
-    const ownerAuthority = m.getParameter('ownerAuthority_', OWNER_AUTHORITY);
 
     const RemoteAccountAxelarRouter = m.contract('RemoteAccountAxelarRouter', [
         gateway,
         axelarSourceChain,
         factoryAddress,
         permit2,
-        ownerAuthority,
     ]);
-
-    const factory = m.contractAt('RemoteAccountFactory', factoryAddress);
-
-    m.call(factory, 'transferOwnership', [RemoteAccountAxelarRouter], {
-        id: 'transferFactoryOwnership',
-    });
 
     return { RemoteAccountAxelarRouter };
 });

--- a/packages/axelar-local-dev-cosmos/ignition/modules/deployRemoteAccountFactory.ts
+++ b/packages/axelar-local-dev-cosmos/ignition/modules/deployRemoteAccountFactory.ts
@@ -27,8 +27,6 @@ export default buildModule('RemoteAccountFactoryModule', (m) => {
     });
 
     // Deploy the factory with the implementation address
-    // Explicitly depend on renounceImplementationOwnership so the factory
-    // constructor sees the implementation with owner = address(0)
     const RemoteAccountFactory = m.contract('RemoteAccountFactory', [
         principalCaip2,
         principalAccount,

--- a/packages/axelar-local-dev-cosmos/ignition/modules/deployRemoteAccountFactory.ts
+++ b/packages/axelar-local-dev-cosmos/ignition/modules/deployRemoteAccountFactory.ts
@@ -3,28 +3,27 @@ import { config } from 'dotenv';
 
 config();
 
-const { PRINCIPAL_CAIP2, PRINCIPAL_ACCOUNT } = process.env;
+const { PRINCIPAL_CAIP2, PRINCIPAL_ACCOUNT, VETTING_AUTHORITY } = process.env;
 
 console.log('Deploying RemoteAccountFactory with:');
 console.log('  Principal CAIP2:', PRINCIPAL_CAIP2);
 console.log('  Principal Account:', PRINCIPAL_ACCOUNT);
+console.log('  Vetting Authority:', VETTING_AUTHORITY);
 
-if (!PRINCIPAL_CAIP2 || !PRINCIPAL_ACCOUNT) {
-    throw new Error('Missing required env vars: PRINCIPAL_CAIP2 or PRINCIPAL_ACCOUNT');
+if (!PRINCIPAL_CAIP2 || !PRINCIPAL_ACCOUNT || !VETTING_AUTHORITY) {
+    throw new Error(
+        'Missing required env vars: PRINCIPAL_CAIP2 or PRINCIPAL_ACCOUNT or VETTING_AUTHORITY',
+    );
 }
 
 export default buildModule('RemoteAccountFactoryModule', (m) => {
     const principalCaip2 = m.getParameter('principalCaip2_', PRINCIPAL_CAIP2);
     const principalAccount = m.getParameter('principalAccount_', PRINCIPAL_ACCOUNT);
+    const vettingAuthority = m.getParameter('vettingAuthority_', VETTING_AUTHORITY);
 
     // Deploy the RemoteAccount implementation contract first
     const RemoteAccountImplementation = m.contract('RemoteAccount', [], {
         id: 'RemoteAccountImplementation',
-    });
-
-    // Renounce ownership on the implementation to make it inert
-    const renounceImplementationOwnership = m.call(RemoteAccountImplementation, 'renounceOwnership', [], {
-        id: 'renounceImplementationOwnership',
     });
 
     // Deploy the factory with the implementation address
@@ -34,9 +33,8 @@ export default buildModule('RemoteAccountFactoryModule', (m) => {
         principalCaip2,
         principalAccount,
         RemoteAccountImplementation,
-    ], {
-        after: [renounceImplementationOwnership],
-    });
+        vettingAuthority,
+    ]);
 
     return { RemoteAccountImplementation, RemoteAccountFactory };
 });

--- a/packages/axelar-local-dev-cosmos/package.json
+++ b/packages/axelar-local-dev-cosmos/package.json
@@ -24,7 +24,7 @@
     "relayWithTokens": "ts-node scripts/runner.ts relayWithTokens",
     "testWallet": "ts-node scripts/runner.ts testWallet",
     "testFactory": "ts-node scripts/runner.ts testFactory",
-    "test:proxy": "hardhat test src/__tests__/Factory.spec.ts src/__tests__/DepositFactory.spec.ts src/__tests__/RemoteAccountCreation.spec.ts src/__tests__/RemoteAccountMulticall.spec.ts src/__tests__/RemoteAccountDeposit.spec.ts  src/__tests__/RemoteAccountRouter.spec.ts",
+    "test:proxy": "hardhat test src/__tests__/Factory.spec.ts src/__tests__/DepositFactory.spec.ts src/__tests__/RemoteAccountCreation.spec.ts src/__tests__/RemoteAccountMulticall.spec.ts src/__tests__/RemoteAccountDeposit.spec.ts src/__tests__/RemoteAccountRouter.spec.ts src/__tests__/RemoteAccountVetting.spec.ts",
     "coverage:proxy": "npx hardhat coverage --testfiles src/__tests__/Factory.spec.ts",
     "verify": "./scripts/verify.sh",
     "deploy": "./scripts/deploy.sh"

--- a/packages/axelar-local-dev-cosmos/scripts/deploy.sh
+++ b/packages/axelar-local-dev-cosmos/scripts/deploy.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 YMAX0_MAINNET="agoric1wl2529tfdlfvure7mw6zteam02prgaz88p0jru4tlzuxdawrdyys6jlmnq"
 YMAX1_MAINNET="agoric13ecz27mm2ug5kv96jyal2k6z8874mxzs4m4yuet36s4nqdl0ey6qr09p74"
 
@@ -24,18 +26,20 @@ if [[ $# -lt 2 ]]; then
     echo "  Testnets: arb-sepolia, base-sepolia, eth-sepolia, fuji, opt-sepolia"
     echo ""
     echo "Examples:"
-    echo "  $0 eth-sepolia factory              # Deploy Factory"
-    echo "  $0 eth-sepolia depositFactory       # Deploy DepositFactory with ymax0 owner"
-    echo "  $0 eth-sepolia depositFactory ymax1 # Deploy DepositFactory with ymax1 owner"
-    echo "  $0 eth-sepolia remoteAccountFactory       # Deploy RemoteAccountFactory with ymax0 principal"
-    echo "  $0 eth-sepolia remoteAccountFactory ymax1 # Deploy RemoteAccountFactory with ymax1 principal"
+    echo "  $0 eth-sepolia factory               # Deploy Factory"
+    echo "  $0 eth-sepolia depositFactory        # Deploy DepositFactory with ymax0 owner"
+    echo "  $0 eth-sepolia depositFactory ymax1  # Deploy DepositFactory with ymax1 owner"
+    echo ""
+    echo "  # Deploy RemoteAccount (implementation) and RemoteAccountFactory (requires env vars):"
+    echo "  VETTING_AUTHORITY=0x... $0 eth-sepolia remoteAccountFactory       # Deploy with ymax0 principal"
+    echo "  VETTING_AUTHORITY=0x... $0 eth-sepolia remoteAccountFactory ymax1 # Deploy with ymax1 principal"
     echo ""
     echo "  # Deploy RemoteAccountAxelarRouter (requires env vars):"
-    echo "  REMOTE_ACCOUNT_FACTORY=0x... OWNER_AUTHORITY=0x... $0 eth-sepolia portfolioRouter"
+    echo "  REMOTE_ACCOUNT_FACTORY=0x... $0 eth-sepolia portfolioRouter"
     echo ""
     echo "Environment Variables:"
-    echo "  REMOTE_ACCOUNT_FACTORY - Required for portfolioRouter: deployed factory address"
-    echo "  OWNER_AUTHORITY        - Required for portfolioRouter: address that can designate router replacement"
+    echo "  REMOTE_ACCOUNT_FACTORY - Required for portfolioRouter: previously deployed factory address"
+    echo "  VETTING_AUTHORITY      - Required for remoteAccountFactory: address that can vet new routers"
     exit 0
 fi
 
@@ -149,13 +153,15 @@ case "$contract" in
 
         echo ""
         echo "========================================="
-        echo "Deploying RemoteAccountFactory..."
+        echo "Deploying RemoteAccount and RemoteAccountFactory..."
         echo "========================================="
         echo "Using owner type: $owner_type"
         echo "Using Principal CAIP2: $PRINCIPAL_CAIP2"
         echo "Using Principal Account: $PRINCIPAL_ACCOUNT"
+        echo "Using Vetting Authority: $VETTING_AUTHORITY"
         PRINCIPAL_CAIP2="$PRINCIPAL_CAIP2" \
             PRINCIPAL_ACCOUNT="$PRINCIPAL_ACCOUNT" \
+            VETTING_AUTHORITY="$VETTING_AUTHORITY" \
             npx hardhat ignition deploy "./ignition/modules/deployRemoteAccountFactory.ts" --network "$network" --verify
         ;;
 
@@ -170,15 +176,18 @@ case "$contract" in
         echo "========================================="
         echo "Using RemoteAccountFactory: $REMOTE_ACCOUNT_FACTORY"
         echo "Using Axelar Source Chain: $AXELAR_SOURCE_CHAIN"
-        echo "Using Owner Authority: $OWNER_AUTHORITY"
-
 
         GATEWAY_CONTRACT="$GATEWAY" \
             AXELAR_SOURCE_CHAIN="$AXELAR_SOURCE_CHAIN" \
             FACTORY_CONTRACT="$REMOTE_ACCOUNT_FACTORY" \
             PERMIT2_CONTRACT="$PERMIT2" \
-            OWNER_AUTHORITY="$OWNER_AUTHORITY" \
             npx hardhat ignition deploy "./ignition/modules/deployPortfolioRouter.ts" --network "$network" --verify
+        # Vet router after deployment
+        GATEWAY_CONTRACT="$GATEWAY" \
+            AXELAR_SOURCE_CHAIN="$AXELAR_SOURCE_CHAIN" \
+            FACTORY_CONTRACT="$REMOTE_ACCOUNT_FACTORY" \
+            PERMIT2_CONTRACT="$PERMIT2" \
+            npx hardhat run "./scripts/deployAndVetPortfolioRouter.mts" --network "$network"
         ;;
     *)
         echo "Error: Invalid contract type '$contract'"

--- a/packages/axelar-local-dev-cosmos/scripts/deployAndVetPortfolioRouter.mts
+++ b/packages/axelar-local-dev-cosmos/scripts/deployAndVetPortfolioRouter.mts
@@ -1,0 +1,41 @@
+import hre from 'hardhat';
+import PortfolioRouter from '../ignition/modules/deployPortfolioRouter.ts';
+
+async function main() {
+    // This will NOT re-deploy if already on-chain; it just returns the existing instance.
+    const { RemoteAccountAxelarRouter } = await hre.ignition.deploy(PortfolioRouter);
+
+    const [deployer] = await hre.ethers.getSigners();
+
+    const routerAddress = await RemoteAccountAxelarRouter.getAddress();
+    const factoryAddress = await RemoteAccountAxelarRouter.factory();
+    const factory = await hre.ethers.getContractAt('RemoteAccountFactory', factoryAddress);
+
+    const [status, numberOfRouters, vettingAuthority] = await Promise.all([
+        factory.getRouterStatus(routerAddress),
+        factory.numberOfAuthorizedRouters(),
+        factory.vettingAuthority(),
+    ]);
+
+    console.log(`Post-deployment of Portfolio Router at ${routerAddress}:`);
+    console.log(`Status in factory: ${status}`);
+    console.log(`Number of Authorized Routers in factory: ${numberOfRouters}`);
+    console.log(`Vetting Authority: ${vettingAuthority}`);
+    console.log(`Deployer address: ${deployer.address}`);
+
+    if (status !== 0n) {
+        console.log('Router status already set, skipping vetting.');
+    } else if (vettingAuthority !== deployer.address) {
+        console.warn('Deployer is not the vetting authority. Skipping vetting deployed router.');
+    } else if (numberOfRouters > 0n) {
+        console.log(
+            'Vetting router. This is not the initial router, it must be enabled through an existing router.',
+        );
+        await factory.vetRouter(routerAddress);
+    } else {
+        console.log('Vetting and enabling initial router.');
+        await factory.vetInitialRouter(routerAddress);
+    }
+}
+
+await main();

--- a/packages/axelar-local-dev-cosmos/scripts/deployAndVetPortfolioRouter.mts
+++ b/packages/axelar-local-dev-cosmos/scripts/deployAndVetPortfolioRouter.mts
@@ -1,3 +1,4 @@
+import '@nomicfoundation/hardhat-ignition-ethers';
 import hre from 'hardhat';
 import PortfolioRouter from '../ignition/modules/deployPortfolioRouter.ts';
 
@@ -31,10 +32,14 @@ async function main() {
         console.log(
             'Vetting router. This is not the initial router, it must be enabled through an existing router.',
         );
-        await factory.vetRouter(routerAddress);
+        const vetTx = await factory.vetRouter(routerAddress);
+        const vetReceipt = await vetTx.wait();
+        console.log(`vetRouter tx: ${vetReceipt.hash} (status: ${vetReceipt.status})`);
     } else {
         console.log('Vetting and enabling initial router.');
-        await factory.vetInitialRouter(routerAddress);
+        const vetTx = await factory.vetInitialRouter(routerAddress);
+        const vetReceipt = await vetTx.wait();
+        console.log(`vetInitialRouter tx: ${vetReceipt.hash} (status: ${vetReceipt.status})`);
     }
 }
 

--- a/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountCreation.spec.ts
+++ b/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountCreation.spec.ts
@@ -164,7 +164,7 @@ describe('RemoteAccountAxelarRouter - RemoteAccountCreation', () => {
         ).to.be.revertedWithCustomError(factory, 'InvalidAccountAtAddress');
     });
 
-    it('should allow enabled router to create and operate accounts', async () => {
+    it('should allow authorized router to create and operate accounts', async () => {
         // Deploy a second router
         const RouterContract = await ethers.getContractFactory('RemoteAccountAxelarRouter');
         const secondRouter = await RouterContract.deploy(
@@ -178,18 +178,18 @@ describe('RemoteAccountAxelarRouter - RemoteAccountCreation', () => {
         // Vet the second router via the current router (factory owner)
         await factory.getFunction('vetRouter')(secondRouter.target);
 
-        // Enable the second router via GMP from factory principal
-        const enableReceipt = await route(portfolioContractAccount).doEnableRouter({
+        // Authorize the second router via GMP from factory principal
+        const authorizeReceipt = await route(portfolioContractAccount).doAuthorizeRouter({
             router: secondRouter.target as `0x${string}`,
         });
-        enableReceipt.expectOperationSuccess();
+        authorizeReceipt.expectOperationSuccess();
 
         // Verify the second router is authorized
         expect(await factory.getFunction('isAuthorizedRouter')(secondRouter.target)).to.equal(true);
 
         // Second router can create and operate accounts
         const secondRoute = routed(secondRouter, routeConfig);
-        const newLCA = 'agoric1enabledroutertest123456789abcde';
+        const newLCA = 'agoric1authorizedroutertest123456789ab';
         const receipt = await secondRoute(newLCA).doRemoteAccountExecute({ multiCalls: [] });
         receipt.expectOperationSuccess();
     });

--- a/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountCreation.spec.ts
+++ b/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountCreation.spec.ts
@@ -199,7 +199,7 @@ describe('RemoteAccountAxelarRouter - RemoteAccountCreation', () => {
         const account = await ethers.getContractAt('RemoteAccount', implementationAddress);
 
         // Try to call initialize on the implementation contract
-        await expect(account.initialize(addr1.address)).to.be.revertedWithCustomError(
+        await expect(account.initialize(ethers.ZeroAddress, '')).to.be.revertedWithCustomError(
             account,
             'InvalidInitialization',
         );
@@ -214,7 +214,7 @@ describe('RemoteAccountAxelarRouter - RemoteAccountCreation', () => {
         const account = await ethers.getContractAt('RemoteAccount', accountAddress);
 
         // Try to call initialize again on the clone
-        await expect(account.initialize(addr1.address)).to.be.revertedWithCustomError(
+        await expect(account.initialize(addr1.address, lca)).to.be.revertedWithCustomError(
             account,
             'InvalidInitialization',
         );

--- a/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountCreation.spec.ts
+++ b/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountCreation.spec.ts
@@ -4,7 +4,7 @@ import { Contract } from 'ethers';
 import { ethers } from 'hardhat';
 import '@nomicfoundation/hardhat-chai-matchers';
 import { HardhatEthersSigner } from '@nomicfoundation/hardhat-ethers/signers';
-import { routed, deployRemoteAccountFactory, predictDeployAddress } from './lib/utils';
+import { routed, deployRemoteAccountFactory } from './lib/utils';
 
 describe('RemoteAccountAxelarRouter - RemoteAccountCreation', () => {
     let owner: HardhatEthersSigner, addr1: HardhatEthersSigner;
@@ -52,14 +52,11 @@ describe('RemoteAccountAxelarRouter - RemoteAccountCreation', () => {
         const MockPermit2Factory = await ethers.getContractFactory('MockPermit2');
         permit2Mock = await MockPermit2Factory.deploy();
 
-        // Predict the router address so the factory can enable it at construction
-        const predictedRouterAddress = await predictDeployAddress(owner, 2);
-
         // Deploy RemoteAccount implementation + RemoteAccountFactory
         factory = await deployRemoteAccountFactory(
             portfolioContractCaip2,
             portfolioContractAccount,
-            predictedRouterAddress,
+            owner.address,
         );
 
         // Deploy RemoteAccountAxelarRouter
@@ -71,6 +68,8 @@ describe('RemoteAccountAxelarRouter - RemoteAccountCreation', () => {
             permit2Mock.target,
         );
         await router.waitForDeployment();
+
+        await factory.getFunction('vetInitialRouter')(router.target);
 
         routeConfig = {
             sourceChain,

--- a/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountCreation.spec.ts
+++ b/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountCreation.spec.ts
@@ -4,8 +4,7 @@ import { Contract } from 'ethers';
 import { ethers } from 'hardhat';
 import '@nomicfoundation/hardhat-chai-matchers';
 import { HardhatEthersSigner } from '@nomicfoundation/hardhat-ethers/signers';
-import * as helpers from '@nomicfoundation/hardhat-network-helpers';
-import { routed, deployRemoteAccountFactory } from './lib/utils';
+import { routed, deployRemoteAccountFactory, predictDeployAddress } from './lib/utils';
 
 describe('RemoteAccountAxelarRouter - RemoteAccountCreation', () => {
     let owner: HardhatEthersSigner, addr1: HardhatEthersSigner;
@@ -53,10 +52,14 @@ describe('RemoteAccountAxelarRouter - RemoteAccountCreation', () => {
         const MockPermit2Factory = await ethers.getContractFactory('MockPermit2');
         permit2Mock = await MockPermit2Factory.deploy();
 
+        // Predict the router address so the factory can enable it at construction
+        const predictedRouterAddress = await predictDeployAddress(owner, 2);
+
         // Deploy RemoteAccount implementation + RemoteAccountFactory
         factory = await deployRemoteAccountFactory(
             portfolioContractCaip2,
             portfolioContractAccount,
+            predictedRouterAddress,
         );
 
         // Deploy RemoteAccountAxelarRouter
@@ -66,15 +69,8 @@ describe('RemoteAccountAxelarRouter - RemoteAccountCreation', () => {
             sourceChain,
             factory.target,
             permit2Mock.target,
-            owner.address, // ownerAuthority
         );
         await router.waitForDeployment();
-
-        // Vet the router before transferring ownership
-        await factory.vetRouter(router.target);
-
-        // Transfer factory ownership to router
-        await factory.transferOwnership(router.target);
 
         routeConfig = {
             sourceChain,
@@ -140,16 +136,17 @@ describe('RemoteAccountAxelarRouter - RemoteAccountCreation', () => {
     it('should reject unauthorized callers for publicly created remote accounts', async () => {
         const frontRunLCA = 'agoric1frontruntest123456789abcdefghij';
 
-        // Compute the expected address
+        // Anyone can call provideRemoteAccount to create the account
         const expectedAddress = await route(frontRunLCA).getRemoteAccountAddress();
+        await factory.connect(addr1).getFunction('provideRemoteAccount')(
+            frontRunLCA,
+            expectedAddress,
+        );
 
-        // Attacker tries to front-run by calling factory.provideRemoteAccount directly
-        // This should revert because the caller is not authorized
+        // But only authorized routers can operate the created account
+        const account = await ethers.getContractAt('RemoteAccount', expectedAddress);
         await expect(
-            factory.connect(addr1).getFunction('provideRemoteAccount')(
-                frontRunLCA,
-                expectedAddress,
-            ),
+            account.connect(addr1).getFunction('executeCalls')([]),
         ).to.be.revertedWithCustomError(factory, 'UnauthorizedCaller');
     });
 
@@ -176,12 +173,11 @@ describe('RemoteAccountAxelarRouter - RemoteAccountCreation', () => {
             sourceChain,
             factory.target,
             permit2Mock.target,
-            owner.address,
         );
         await secondRouter.waitForDeployment();
 
         // Vet the second router via the current router (factory owner)
-        await router.vetRouter(secondRouter.target);
+        await factory.getFunction('vetRouter')(secondRouter.target);
 
         // Enable the second router via GMP from factory principal
         const enableReceipt = await route(portfolioContractAccount).doEnableRouter({
@@ -190,7 +186,7 @@ describe('RemoteAccountAxelarRouter - RemoteAccountCreation', () => {
         enableReceipt.expectOperationSuccess();
 
         // Verify the second router is authorized
-        expect(await factory.isAuthorizedCaller(secondRouter.target)).to.equal(true);
+        expect(await factory.getFunction('isAuthorizedRouter')(secondRouter.target)).to.equal(true);
 
         // Second router can create and operate accounts
         const secondRoute = routed(secondRouter, routeConfig);

--- a/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountCreation.spec.ts
+++ b/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountCreation.spec.ts
@@ -199,7 +199,7 @@ describe('RemoteAccountAxelarRouter - RemoteAccountCreation', () => {
         const account = await ethers.getContractAt('RemoteAccount', implementationAddress);
 
         // Try to call initialize on the implementation contract
-        await expect(account.initialize(ethers.ZeroAddress, '')).to.be.revertedWithCustomError(
+        await expect(account.initialize(addr1.address)).to.be.revertedWithCustomError(
             account,
             'InvalidInitialization',
         );
@@ -214,7 +214,7 @@ describe('RemoteAccountAxelarRouter - RemoteAccountCreation', () => {
         const account = await ethers.getContractAt('RemoteAccount', accountAddress);
 
         // Try to call initialize again on the clone
-        await expect(account.initialize(addr1.address, lca)).to.be.revertedWithCustomError(
+        await expect(account.initialize(addr1.address)).to.be.revertedWithCustomError(
             account,
             'InvalidInitialization',
         );

--- a/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountCreation.spec.ts
+++ b/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountCreation.spec.ts
@@ -70,6 +70,9 @@ describe('RemoteAccountAxelarRouter - RemoteAccountCreation', () => {
         );
         await router.waitForDeployment();
 
+        // Vet the router before transferring ownership
+        await factory.vetRouter(router.target);
+
         // Transfer factory ownership to router
         await factory.transferOwnership(router.target);
 
@@ -100,19 +103,17 @@ describe('RemoteAccountAxelarRouter - RemoteAccountCreation', () => {
         receipt.expectOperationSuccess();
 
         const expectedAccountAddress = await route(portfolioLCA).getRemoteAccountAddress();
-        const RemoteAccountContract = await ethers.getContractFactory('RemoteAccount');
-        const account = RemoteAccountContract.attach(expectedAccountAddress);
-        expect(await account.owner()).to.equal(router.target);
+        const account = await ethers.getContractAt('RemoteAccount', expectedAccountAddress);
+        expect(await account.factory()).to.equal(factory.target);
     });
 
-    it('should be idempotent - providing same account twice succeeds with created=false', async () => {
+    it('should be idempotent - providing same account twice succeeds', async () => {
         const receipt = await route(portfolioLCA).doRemoteAccountExecute({ multiCalls: [] });
         receipt.expectOperationSuccess();
 
         const expectedAccountAddress = await route(portfolioLCA).getRemoteAccountAddress();
-        const RemoteAccountContract = await ethers.getContractFactory('RemoteAccount');
-        const account = RemoteAccountContract.attach(expectedAccountAddress);
-        expect(await account.owner()).to.equal(router.target);
+        const account = await ethers.getContractAt('RemoteAccount', expectedAccountAddress);
+        expect(await account.factory()).to.equal(factory.target);
     });
 
     it('should reject when expected address does not match', async () => {
@@ -136,59 +137,26 @@ describe('RemoteAccountAxelarRouter - RemoteAccountCreation', () => {
         expect(decodedError?.args.actual).to.equal(expectedCorrectAddress);
     });
 
-    it('should reject when ownership was transferred away from router', async () => {
-        const transferTestLCA = 'agoric1transfertest123456789abcdefghij';
-
-        const expectedAccountAddress = await route(transferTestLCA).getRemoteAccountAddress();
-
-        // Step 1: Create account via router
-        await route(transferTestLCA).doRemoteAccountExecute({ multiCalls: [] });
-
-        // Step 2: Transfer ownership away from router (impersonate router)
-        const account = await ethers.getContractAt('RemoteAccount', expectedAccountAddress);
-
-        await helpers.impersonateAccount(router.target.toString());
-        await helpers.setBalance(router.target.toString(), ethers.parseEther('100'));
-        const routerSigner = await ethers.getSigner(router.target.toString());
-
-        await account.connect(routerSigner).getFunction('transferOwnership')(addr1.address);
-        await helpers.stopImpersonatingAccount(router.target.toString());
-
-        // Verify ownership transferred
-        expect(await account.owner()).to.equal(addr1.address);
-
-        // Step 3: Try to provide again via router - should fail
-        const receipt = await route(transferTestLCA).doRemoteAccountExecute({ multiCalls: [] });
-        const decodedError = receipt.parseOperationError(factory.interface);
-        expect(decodedError?.name).to.equal('UnauthorizedOwner');
-        expect(decodedError?.args.account).to.equal(expectedAccountAddress);
-        expect(decodedError?.args.owner).to.equal(router.target);
-    });
-
-    it('should reject provideRemoteAccount calls with unauthorized owner', async () => {
+    it('should reject unauthorized callers for publicly created remote accounts', async () => {
         const frontRunLCA = 'agoric1frontruntest123456789abcdefghij';
 
         // Compute the expected address
         const expectedAddress = await route(frontRunLCA).getRemoteAccountAddress();
 
         // Attacker tries to front-run by calling factory.provideRemoteAccount directly
-        // This should revert because the public method cannot be used with arbitrary owners
+        // This should revert because the caller is not authorized
         await expect(
-            factory.provideRemoteAccount(
+            factory.connect(addr1).getFunction('provideRemoteAccount')(
                 frontRunLCA,
-                addr1.address, // attacker tries to use themselves as router
                 expectedAddress,
             ),
-        ).to.be.revertedWithCustomError(factory, 'UnauthorizedOwner');
+        ).to.be.revertedWithCustomError(factory, 'UnauthorizedCaller');
     });
 
     it('should refuse creating an account for the factory principal', async () => {
-        // Attacker tries to front-run by calling factory.provideRemoteAccount directly
-        // This should revert because factory only does a verify for calls not from its owner (router)
         await expect(
-            factory.provideRemoteAccount(
+            factory.getFunction('provideRemoteAccount')(
                 portfolioContractAccount,
-                router.target,
                 ethers.ZeroAddress,
             ),
         ).to.be.revertedWithCustomError(factory, 'InvalidAccountAtAddress');
@@ -200,112 +168,40 @@ describe('RemoteAccountAxelarRouter - RemoteAccountCreation', () => {
         ).to.be.revertedWithCustomError(factory, 'InvalidAccountAtAddress');
     });
 
-    it('should create account for a different owner via provideRemoteAccountForOwner', async () => {
-        // Get current factory owner (may have changed from previous tests)
-        const factoryOwnerAddress = await factory.owner();
-        const factoryOwnerRouter = await ethers.getContractAt(
-            'RemoteAccountAxelarRouter',
-            factoryOwnerAddress,
-        );
-
-        // Deploy a target router that will own the new account
+    it('should allow enabled router to create and operate accounts', async () => {
+        // Deploy a second router
         const RouterContract = await ethers.getContractFactory('RemoteAccountAxelarRouter');
-        const targetRouter = await RouterContract.deploy(
+        const secondRouter = await RouterContract.deploy(
             axelarGatewayMock.target,
             sourceChain,
             factory.target,
             permit2Mock.target,
             owner.address,
         );
-        await targetRouter.waitForDeployment();
+        await secondRouter.waitForDeployment();
 
-        // router will call the factory's provideRemoteAccountForOwner
-        // Must be executed by the router that currently owns the factory
-        const factoryOwnerRoute = routed(factoryOwnerRouter, routeConfig);
+        // Vet the second router via the current router (factory owner)
+        await router.vetRouter(secondRouter.target);
 
-        // Compute address for the new account
-        const newPortfolioLCA = 'agoric1provideforowner123456789abcdef';
-        const newAccountAddress = await factory.getRemoteAccountAddress(newPortfolioLCA);
-
-        // Impersonate the router (factory owner) to call provideRemoteAccountForOwner directly
-        await helpers.impersonateAccount(factoryOwnerAddress);
-        await helpers.setBalance(factoryOwnerAddress, ethers.parseEther('1'));
-        const routerSigner = await ethers.getSigner(factoryOwnerAddress);
-
-        // Create account owned by addr1 instead of the router
-        await expect(
-            factory.connect(routerSigner).getFunction('provideRemoteAccountForOwner')(
-                newPortfolioLCA,
-                targetRouter.target,
-                newAccountAddress,
-            ),
-        )
-            .to.emit(factory, 'RemoteAccountCreated')
-            .withArgs(newAccountAddress, newPortfolioLCA, targetRouter.target.toString());
-
-        await helpers.stopImpersonatingAccount(factoryOwnerAddress);
-
-        // Verify account was created and is owned by targetRouter
-        const newAccount = await ethers.getContractAt('RemoteAccount', newAccountAddress);
-        expect(await newAccount.owner()).to.equal(targetRouter.target);
-
-        // Verify idempotent: calling again with same owner succeeds (returns false)
-        await helpers.impersonateAccount(factoryOwnerAddress);
-        const routerSigner2 = await ethers.getSigner(factoryOwnerAddress);
-        await factory.connect(routerSigner2).getFunction('provideRemoteAccountForOwner')(
-            newPortfolioLCA,
-            targetRouter.target,
-            newAccountAddress,
-        );
-        await helpers.stopImpersonatingAccount(factoryOwnerAddress);
-
-        // Verify factory ownership unchanged
-        expect(await factory.owner()).to.equal(factoryOwnerAddress);
-
-        // Verify targetRouter can execute instructions on the new account
-        const targetRoute = routed(targetRouter, routeConfig);
-
-        const receipt2 = await targetRoute(newPortfolioLCA).doRemoteAccountExecute({
-            multiCalls: [],
+        // Enable the second router via GMP from factory principal
+        const enableReceipt = await route(portfolioContractAccount).doEnableRouter({
+            router: secondRouter.target as `0x${string}`,
         });
-        receipt2.expectOperationSuccess();
+        enableReceipt.expectOperationSuccess();
 
-        // Verify factory owner router cannot execute instructions on the new account (owned by targetRouter)
-        const receipt3 = await factoryOwnerRoute(newPortfolioLCA).doRemoteAccountExecute({
-            multiCalls: [],
-        });
-        const decodedError = receipt3.parseOperationError(factory.interface);
-        expect(decodedError?.name).to.equal('UnauthorizedOwner');
-    });
+        // Verify the second router is authorized
+        expect(await factory.isAuthorizedCaller(secondRouter.target)).to.equal(true);
 
-    it('should reject provideRemoteAccountForOwner from non-owner', async () => {
-        const lca = 'agoric1nonownertest123456789abcdefghij';
-        const accountAddress = await factory.getRemoteAccountAddress(lca);
-
-        await expect(
-            factory.connect(addr1).getFunction('provideRemoteAccountForOwner')(
-                lca,
-                addr1.address,
-                accountAddress,
-            ),
-        ).to.be.revertedWithCustomError(factory, 'OwnableUnauthorizedAccount');
-    });
-
-    it('should reject factory creation if RemoteAccount implementation is not inert', async () => {
-        const RemoteAccountContract = await ethers.getContractFactory('RemoteAccount');
-        const impl = await RemoteAccountContract.deploy();
-        await impl.waitForDeployment();
-
-        const FactoryContract = await ethers.getContractFactory('RemoteAccountFactory');
-        await expect(
-            FactoryContract.deploy('foo', 'bar', impl.target),
-        ).to.be.revertedWithCustomError(FactoryContract, 'UnauthorizedOwner');
+        // Second router can create and operate accounts
+        const secondRoute = routed(secondRouter, routeConfig);
+        const newLCA = 'agoric1enabledroutertest123456789abcde';
+        const receipt = await secondRoute(newLCA).doRemoteAccountExecute({ multiCalls: [] });
+        receipt.expectOperationSuccess();
     });
 
     it('should disallow initializing the RemoteAccount implementation contract', async () => {
         const implementationAddress = await factory.implementation();
         const account = await ethers.getContractAt('RemoteAccount', implementationAddress);
-        expect(await account.owner()).to.equal(ethers.ZeroAddress);
 
         // Try to call initialize on the implementation contract
         await expect(account.initialize(addr1.address)).to.be.revertedWithCustomError(
@@ -323,21 +219,6 @@ describe('RemoteAccountAxelarRouter - RemoteAccountCreation', () => {
         const account = await ethers.getContractAt('RemoteAccount', accountAddress);
 
         // Try to call initialize again on the clone
-        await expect(account.initialize(addr1.address)).to.be.revertedWithCustomError(
-            account,
-            'InvalidInitialization',
-        );
-
-        // Renounce ownership by first updating ownership through the successor mechanism
-        await expect(router.setSuccessor(owner.address)).to.emit(router, 'SuccessorSet');
-        const updateReceipt = await route(lca).doUpdateOwner({
-            newOwner: owner.address as `0x${string}`,
-        });
-        updateReceipt.expectOperationSuccess();
-        await expect(account.renounceOwnership()).to.emit(account, 'OwnershipTransferred');
-        expect(await account.owner()).to.equal(ethers.ZeroAddress);
-
-        // Try to call initialize after ownership has been renounced
         await expect(account.initialize(addr1.address)).to.be.revertedWithCustomError(
             account,
             'InvalidInitialization',

--- a/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountDeposit.spec.ts
+++ b/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountDeposit.spec.ts
@@ -4,12 +4,7 @@ import { Contract } from 'ethers';
 import { ethers } from 'hardhat';
 import '@nomicfoundation/hardhat-chai-matchers';
 import { HardhatEthersSigner } from '@nomicfoundation/hardhat-ethers/signers';
-import {
-    computeRemoteAccountAddress,
-    deployRemoteAccountFactory,
-    predictDeployAddress,
-    routed,
-} from './lib/utils';
+import { computeRemoteAccountAddress, deployRemoteAccountFactory, routed } from './lib/utils';
 import type { DepositPermit } from '../interfaces/router.ts';
 
 /**
@@ -65,14 +60,11 @@ describe('RemoteAccountAxelarRouter - RemoteAccountDeposit', () => {
         const MockPermit2Factory = await ethers.getContractFactory('MockPermit2');
         permit2Mock = await MockPermit2Factory.deploy();
 
-        // Predict the router address so the factory can enable it at construction
-        const predictedRouterAddress = await predictDeployAddress(owner, 2);
-
         // Deploy RemoteAccount implementation + RemoteAccountFactory
         factory = await deployRemoteAccountFactory(
             portfolioContractCaip2,
             portfolioContractAccount,
-            predictedRouterAddress,
+            owner.address,
         );
 
         // Deploy RemoteAccountAxelarRouter
@@ -84,6 +76,8 @@ describe('RemoteAccountAxelarRouter - RemoteAccountDeposit', () => {
             permit2Mock.target,
         );
         await router.waitForDeployment();
+
+        await factory.getFunction('vetInitialRouter')(router.target);
 
         // Deploy test token
         const MockERC20Factory = await ethers.getContractFactory('MockERC20');

--- a/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountDeposit.spec.ts
+++ b/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountDeposit.spec.ts
@@ -4,7 +4,12 @@ import { Contract } from 'ethers';
 import { ethers } from 'hardhat';
 import '@nomicfoundation/hardhat-chai-matchers';
 import { HardhatEthersSigner } from '@nomicfoundation/hardhat-ethers/signers';
-import { computeRemoteAccountAddress, deployRemoteAccountFactory, routed } from './lib/utils';
+import {
+    computeRemoteAccountAddress,
+    deployRemoteAccountFactory,
+    predictDeployAddress,
+    routed,
+} from './lib/utils';
 import type { DepositPermit } from '../interfaces/router.ts';
 
 /**
@@ -60,10 +65,14 @@ describe('RemoteAccountAxelarRouter - RemoteAccountDeposit', () => {
         const MockPermit2Factory = await ethers.getContractFactory('MockPermit2');
         permit2Mock = await MockPermit2Factory.deploy();
 
+        // Predict the router address so the factory can enable it at construction
+        const predictedRouterAddress = await predictDeployAddress(owner, 2);
+
         // Deploy RemoteAccount implementation + RemoteAccountFactory
         factory = await deployRemoteAccountFactory(
             portfolioContractCaip2,
             portfolioContractAccount,
+            predictedRouterAddress,
         );
 
         // Deploy RemoteAccountAxelarRouter
@@ -73,15 +82,8 @@ describe('RemoteAccountAxelarRouter - RemoteAccountDeposit', () => {
             sourceChain,
             factory.target,
             permit2Mock.target,
-            owner.address, // ownerAuthority
         );
         await router.waitForDeployment();
-
-        // Vet the router before transferring ownership
-        await factory.vetRouter(router.target);
-
-        // Transfer factory ownership to router
-        await factory.transferOwnership(router.target);
 
         // Deploy test token
         const MockERC20Factory = await ethers.getContractFactory('MockERC20');

--- a/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountDeposit.spec.ts
+++ b/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountDeposit.spec.ts
@@ -77,6 +77,9 @@ describe('RemoteAccountAxelarRouter - RemoteAccountDeposit', () => {
         );
         await router.waitForDeployment();
 
+        // Vet the router before transferring ownership
+        await factory.vetRouter(router.target);
+
         // Transfer factory ownership to router
         await factory.transferOwnership(router.target);
 

--- a/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountMulticall.spec.ts
+++ b/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountMulticall.spec.ts
@@ -101,6 +101,9 @@ describe('RemoteAccountAxelarRouter - RemoteAccountMulticall', () => {
         await router.waitForDeployment();
 
         // Transfer factory ownership to router
+        // Vet the router before transferring ownership
+        await factory.vetRouter(router.target);
+
         await factory.transferOwnership(router.target);
 
         // Deploy Multicall target for tests
@@ -304,7 +307,7 @@ describe('RemoteAccountAxelarRouter - RemoteAccountMulticall', () => {
         expect(decodedError?.name).to.equal('AddressMismatch');
     });
 
-    it('should update owner of remote account with successor check', async () => {
+    it('should transfer factory ownership to vetted router via UpdateOwner', async () => {
         // Deploy a new router
         const RouterContract = await ethers.getContractFactory('RemoteAccountAxelarRouter');
         const newRouter = await RouterContract.deploy(
@@ -312,78 +315,17 @@ describe('RemoteAccountAxelarRouter - RemoteAccountMulticall', () => {
             sourceChain,
             factory.target,
             permit2Mock.target,
-            owner.address, // ownerAuthority
+            owner.address,
         );
         await newRouter.waitForDeployment();
 
-        // Old router owner pre-designates the successor
-        const previousSuccessor = await router.getFunction('successor')();
-        await expect(router.getFunction('setSuccessor')(newRouter.target))
-            .to.emit(router, 'SuccessorSet')
-            .withArgs(previousSuccessor, newRouter.target);
-
-        // Verify successor was set
-        expect(await router.getFunction('successor')()).to.equal(newRouter.target);
-
-        // Verify RemoteAccount is still owned by old router before transfer
-        const remoteAccount = await ethers.getContractAt('RemoteAccount', accountAddress);
-        expect(await remoteAccount.owner()).to.equal(router.target);
-
-        // Execute UpdateOwner to transfer ownership
-        const receipt = await route(portfolioLCA).doUpdateOwner({
-            newOwner: newRouter.target as `0x${string}`,
-        });
-        receipt.expectOperationSuccess();
-
-        // Verify ownership was transferred
-        expect(await remoteAccount.owner()).to.equal(newRouter.target);
-
-        const multiCalls2: ContractCall[] = [multicallContract.setValue(999n)];
-
-        const receipt2 = await route(portfolioLCA).doRemoteAccountExecute({
-            multiCalls: multiCalls2,
-        });
-
-        const decodedError = receipt2.parseOperationError(factory.interface);
-        expect(decodedError?.name).to.equal('UnauthorizedOwner');
-
-        // New router should succeed
-        const newRoute = routed(newRouter, routeConfig);
-
-        const receipt3 = await newRoute(portfolioLCA).doRemoteAccountExecute({
-            multiCalls: multiCalls2,
-        });
-        receipt3.expectOperationSuccess();
-        expect(await multicallTarget.getValue()).to.equal(999n);
-    });
-
-    it('should transfer factory ownership and create new account with new router', async () => {
-        // Deploy a new router
-        const RouterContract = await ethers.getContractFactory('RemoteAccountAxelarRouter');
-        const newRouter = await RouterContract.deploy(
-            axelarGatewayMock.target,
-            sourceChain,
-            factory.target,
-            permit2Mock.target,
-            owner.address, // ownerAuthority
-        );
-        await newRouter.waitForDeployment();
-
-        // Create a new account with the old router
-        const tmpLCA = 'agoric1templca123456789abcdefghijklmno';
-        (
-            await route(tmpLCA).doRemoteAccountExecute({
-                multiCalls: [],
-            })
-        ).expectOperationSuccess();
-
-        // Old router owner pre-designates its successor
-        await router.getFunction('setSuccessor')(newRouter.target);
+        // Vet the new router via the current router's owner
+        await router.vetRouter(newRouter.target);
 
         // Verify factory is currently owned by old router
         expect(await factory.owner()).to.equal(router.target);
 
-        // Transfer factory ownership via UpdateOwner
+        // Transfer factory ownership via UpdateOwner from factory principal
         (
             await route(portfolioContractAccount).doUpdateOwner({
                 newOwner: newRouter.target as `0x${string}`,
@@ -393,14 +335,9 @@ describe('RemoteAccountAxelarRouter - RemoteAccountMulticall', () => {
         // Verify factory ownership was transferred
         expect(await factory.owner()).to.equal(newRouter.target);
 
-        // Now use new router to create a new account for a different portfolioLCA
-        const newPortfolioLCA = 'agoric1newportfolio123456789abcdefghijk';
-        const newAccountAddress = await computeRemoteAccountAddress(
-            factory.target.toString(),
-            newPortfolioLCA,
-        );
-
+        // New router (now factory owner) can create and operate accounts
         const newRoute = routed(newRouter, routeConfig);
+        const newPortfolioLCA = 'agoric1newportfolio123456789abcdefghijk';
 
         (
             await newRoute(newPortfolioLCA).doRemoteAccountExecute({
@@ -408,99 +345,125 @@ describe('RemoteAccountAxelarRouter - RemoteAccountMulticall', () => {
             })
         ).expectOperationSuccess();
 
-        // Verify new account was created and owned by new router
-        const newAccount = await ethers.getContractAt('RemoteAccount', newAccountAddress);
-        expect(await newAccount.owner()).to.equal(newRouter.target);
+        // New router can execute multicalls on existing accounts (O(1) migration)
+        const multiCalls2: ContractCall[] = [multicallContract.setValue(999n)];
+        const receipt3 = await newRoute(portfolioLCA).doRemoteAccountExecute({
+            multiCalls: multiCalls2,
+        });
+        receipt3.expectOperationSuccess();
+        expect(await multicallTarget.getValue()).to.equal(999n);
 
-        // Verify old router cannot create accounts anymore
-        const anotherPortfolioLCA = 'agoric1anotherportfolio123456789abcdefg';
-        const receiptFailedCreate = await route(anotherPortfolioLCA).doRemoteAccountExecute({
+        // Old router is still enabled (was auto-enabled as previous owner)
+        // It can still operate accounts until explicitly disabled
+        const anotherLCA = 'agoric1anotherportfolio123456789abcdefg';
+        const receiptStillEnabled = await route(anotherLCA).doRemoteAccountExecute({
             multiCalls: [],
         });
-        const decodedError = receiptFailedCreate.parseOperationError(factory.interface);
-        expect(decodedError?.name).to.equal('UnauthorizedOwner');
+        receiptStillEnabled.expectOperationSuccess();
 
-        // Verify old router can update ownership of the accounts it still owns (tmpLCA) to the new router
+        // Disable old router via new router
+        const newRoute2 = routed(newRouter, routeConfig);
         (
-            await route(tmpLCA).doUpdateOwner({
-                newOwner: newRouter.target as `0x${string}`,
+            await newRoute2(portfolioContractAccount).doDisableRouter({
+                router: router.target as `0x${string}`,
             })
         ).expectOperationSuccess();
 
-        const tmpAccount = await ethers.getContractAt(
-            'RemoteAccount',
-            await route(tmpLCA).getRemoteAccountAddress(),
-        );
-        expect(await tmpAccount.owner()).to.equal(newRouter.target);
-    });
-
-    it('should reject UpdateOwner when no successor is designated', async () => {
-        // Deploy a fresh router with no successor set
-        const RouterContract = await ethers.getContractFactory('RemoteAccountAxelarRouter');
-        const freshRouter = await RouterContract.deploy(
-            axelarGatewayMock.target,
-            sourceChain,
-            factory.target,
-            permit2Mock.target,
-            owner.address,
-        );
-        await freshRouter.waitForDeployment();
-
-        // Get current factory owner and set freshRouter as its successor
-        const currentFactoryOwner = await factory.owner();
-        const currentRouter = await ethers.getContractAt(
-            'RemoteAccountAxelarRouter',
-            currentFactoryOwner,
-        );
-        await currentRouter.getFunction('setSuccessor')(freshRouter.target);
-
-        // Transfer factory ownership to freshRouter
-        const currentOwnerRoute = routed(currentRouter, routeConfig);
-        (
-            await currentOwnerRoute(portfolioContractAccount).doUpdateOwner({
-                newOwner: freshRouter.target as `0x${string}`,
-            })
-        ).expectOperationSuccess();
-
-        // freshRouter now owns the factory but has no successor set (default: address(0))
-        expect(await factory.owner()).to.equal(freshRouter.target);
-        expect(await freshRouter.getFunction('successor')()).to.equal(ethers.ZeroAddress);
-
-        // Try to UpdateOwner with address(0) as newOwner — should fail
-        const freshRoute = routed(freshRouter, routeConfig);
-        const receipt = await freshRoute(portfolioContractAccount).doUpdateOwner({
-            newOwner: ethers.ZeroAddress as `0x${string}`,
+        // Now old router cannot operate
+        const yetAnotherLCA = 'agoric1yetanotherlca12345678901234abcde';
+        const receiptFail = await route(yetAnotherLCA).doRemoteAccountExecute({
+            multiCalls: [],
         });
-        const decodedError = receipt.parseOperationError(router.interface);
-        expect(decodedError?.name).to.equal('OwnableInvalidOwner');
+        const decodedError = receiptFail.parseOperationError(factory.interface);
+        expect(decodedError?.name).to.equal('UnauthorizedCaller');
     });
 
-    it('should reject UpdateOwner when newOwner does not match successor', async () => {
+    it('should allow enabled experimental router to operate alongside main router', async () => {
         // Get current factory owner
         const currentFactoryOwner = await factory.owner();
         const currentRouter = await ethers.getContractAt(
             'RemoteAccountAxelarRouter',
             currentFactoryOwner,
         );
+        const currentRoute = routed(currentRouter, routeConfig);
 
-        // Set a successor
+        // Deploy experimental router
         const RouterContract = await ethers.getContractFactory('RemoteAccountAxelarRouter');
-        const designatedSuccessor = await RouterContract.deploy(
+        const expRouter = await RouterContract.deploy(
             axelarGatewayMock.target,
             sourceChain,
             factory.target,
             permit2Mock.target,
             owner.address,
         );
-        await designatedSuccessor.waitForDeployment();
-        await currentRouter.getFunction('setSuccessor')(designatedSuccessor.target);
+        await expRouter.waitForDeployment();
 
-        // Try to transfer to a DIFFERENT address (not the successor)
+        // Vet and enable the experimental router
+        await currentRouter.vetRouter(expRouter.target);
+        (
+            await currentRoute(portfolioContractAccount).doEnableRouter({
+                router: expRouter.target as `0x${string}`,
+            })
+        ).expectOperationSuccess();
+
+        // Experimental router can operate accounts
+        const expRoute = routed(expRouter, routeConfig);
+        const expLCA = 'agoric1experimentalrouter123456789abcde';
+        (
+            await expRoute(expLCA).doRemoteAccountExecute({ multiCalls: [] })
+        ).expectOperationSuccess();
+
+        // Main router can also still operate
+        const mainLCA = 'agoric1mainroutertest12345678901234abcde';
+        (
+            await currentRoute(mainLCA).doRemoteAccountExecute({ multiCalls: [] })
+        ).expectOperationSuccess();
+    });
+
+    it('should reject UpdateOwner when newOwner is not vetted', async () => {
+        // Get current factory owner
+        const currentFactoryOwner = await factory.owner();
+        const currentRouter = await ethers.getContractAt(
+            'RemoteAccountAxelarRouter',
+            currentFactoryOwner,
+        );
         const currentRoute = routed(currentRouter, routeConfig);
+
+        // Try to transfer to an un-vetted address
         const receipt = await currentRoute(portfolioContractAccount).doUpdateOwner({
             newOwner: addr1.address as `0x${string}`,
         });
+        const decodedError = receipt.parseOperationError(factory.interface);
+        expect(decodedError?.name).to.equal('RouterNotVetted');
+    });
+
+    it('should reject UpdateOwner from non-factory-principal', async () => {
+        // Get current factory owner
+        const currentFactoryOwner = await factory.owner();
+        const currentRouter = await ethers.getContractAt(
+            'RemoteAccountAxelarRouter',
+            currentFactoryOwner,
+        );
+        const currentRoute = routed(currentRouter, routeConfig);
+
+        // Deploy and vet a target router
+        const RouterContract = await ethers.getContractFactory('RemoteAccountAxelarRouter');
+        const targetRouter = await RouterContract.deploy(
+            axelarGatewayMock.target,
+            sourceChain,
+            factory.target,
+            permit2Mock.target,
+            owner.address,
+        );
+        await targetRouter.waitForDeployment();
+        await currentRouter.vetRouter(targetRouter.target);
+
+        // Try UpdateOwner from a non-principal source (portfolioLCA resolves to account address, not factory)
+        // The router checks factoryAddress != address(factory), so this should fail with UnauthorizedCaller
+        const receipt = await currentRoute(portfolioLCA).doUpdateOwner({
+            newOwner: targetRouter.target as `0x${string}`,
+        });
         const decodedError = receipt.parseOperationError(router.interface);
-        expect(decodedError?.name).to.equal('OwnableInvalidOwner');
+        expect(decodedError?.name).to.equal('UnauthorizedCaller');
     });
 });

--- a/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountMulticall.spec.ts
+++ b/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountMulticall.spec.ts
@@ -128,7 +128,7 @@ describe('RemoteAccountAxelarRouter - RemoteAccountMulticall', () => {
 
         const receipt = await route(portfolioLCA).doRemoteAccountExecute({ multiCalls });
         const operationResult = receipt.expectOperationSuccess();
-        expect(operationResult.args.sourceAddress).to.equal(portfolioLCA);
+        expect(operationResult.args.txIdPlaintext).to.equal(receipt.txId);
         expect(operationResult.args.sourceAddressIndex.hash).to.equal(
             keccak256(toUtf8Bytes(portfolioLCA)),
         );

--- a/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountMulticall.spec.ts
+++ b/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountMulticall.spec.ts
@@ -12,7 +12,6 @@ import {
     computeRemoteAccountAddress,
     deployRemoteAccountFactory,
     ParsedLog,
-    predictDeployAddress,
     routed,
 } from './lib/utils';
 import { multicallAbi } from './interfaces/multicall';
@@ -84,14 +83,11 @@ describe('RemoteAccountAxelarRouter - RemoteAccountMulticall', () => {
         const MockPermit2Factory = await ethers.getContractFactory('MockPermit2');
         permit2Mock = await MockPermit2Factory.deploy();
 
-        // Predict the router address so the factory can enable it at construction
-        const predictedRouterAddress = await predictDeployAddress(owner, 2);
-
         // Deploy RemoteAccount implementation + RemoteAccountFactory
         factory = await deployRemoteAccountFactory(
             portfolioContractCaip2,
             portfolioContractAccount,
-            predictedRouterAddress,
+            owner.address,
         );
 
         // Deploy RemoteAccountAxelarRouter
@@ -103,6 +99,8 @@ describe('RemoteAccountAxelarRouter - RemoteAccountMulticall', () => {
             permit2Mock.target,
         );
         await router.waitForDeployment();
+
+        await factory.getFunction('vetInitialRouter')(router.target);
 
         // Deploy Multicall target for tests
         const MulticallFactory = await ethers.getContractFactory('Multicall');

--- a/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountMulticall.spec.ts
+++ b/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountMulticall.spec.ts
@@ -100,7 +100,6 @@ describe('RemoteAccountAxelarRouter - RemoteAccountMulticall', () => {
         );
         await router.waitForDeployment();
 
-        // Transfer factory ownership to router
         // Vet the router before transferring ownership
         await factory.vetRouter(router.target);
 

--- a/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountMulticall.spec.ts
+++ b/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountMulticall.spec.ts
@@ -303,7 +303,7 @@ describe('RemoteAccountAxelarRouter - RemoteAccountMulticall', () => {
         expect(decodedError?.name).to.equal('AddressMismatch');
     });
 
-    it('should enable vetted router and allow it to operate accounts', async () => {
+    it('should authorize vetted router and allow it to operate accounts', async () => {
         // Deploy a new router
         const RouterContract = await ethers.getContractFactory('RemoteAccountAxelarRouter');
         const newRouter = await RouterContract.deploy(
@@ -317,9 +317,9 @@ describe('RemoteAccountAxelarRouter - RemoteAccountMulticall', () => {
         // Vet the new router via the current router's owner
         await factory.getFunction('vetRouter')(newRouter.target);
 
-        // Enable the new router via GMP from factory principal
+        // Authorize the new router via GMP from factory principal
         (
-            await route(portfolioContractAccount).doEnableRouter({
+            await route(portfolioContractAccount).doAuthorizeRouter({
                 router: newRouter.target as `0x${string}`,
             })
         ).expectOperationSuccess();
@@ -342,15 +342,15 @@ describe('RemoteAccountAxelarRouter - RemoteAccountMulticall', () => {
         receipt3.expectOperationSuccess();
         expect(await multicallTarget.getValue()).to.equal(999n);
 
-        // Old router is still enabled and can still operate alongside new router
+        // Old router is still authorized and can still operate alongside new router
         const anotherLCA = 'agoric1anotherportfolio123456789abcdefg';
-        const receiptStillEnabled = await route(anotherLCA).doRemoteAccountExecute({
+        const receiptStillAuthorized = await route(anotherLCA).doRemoteAccountExecute({
             multiCalls: [],
         });
-        receiptStillEnabled.expectOperationSuccess();
+        receiptStillAuthorized.expectOperationSuccess();
     });
 
-    it('should allow enabled experimental router to operate alongside main router', async () => {
+    it('should allow authorized experimental router to operate alongside main router', async () => {
         // Deploy experimental router
         const RouterContract = await ethers.getContractFactory('RemoteAccountAxelarRouter');
         const expRouter = await RouterContract.deploy(
@@ -361,10 +361,10 @@ describe('RemoteAccountAxelarRouter - RemoteAccountMulticall', () => {
         );
         await expRouter.waitForDeployment();
 
-        // Vet and enable the experimental router
+        // Vet and authorize the experimental router
         await factory.getFunction('vetRouter')(expRouter.target);
         (
-            await route(portfolioContractAccount).doEnableRouter({
+            await route(portfolioContractAccount).doAuthorizeRouter({
                 router: expRouter.target as `0x${string}`,
             })
         ).expectOperationSuccess();
@@ -381,16 +381,16 @@ describe('RemoteAccountAxelarRouter - RemoteAccountMulticall', () => {
         (await route(mainLCA).doRemoteAccountExecute({ multiCalls: [] })).expectOperationSuccess();
     });
 
-    it('should reject enabling an un-vetted router', async () => {
-        // Try to enable an un-vetted address
-        const receipt = await route(portfolioContractAccount).doEnableRouter({
+    it('should reject authorizing an un-vetted router', async () => {
+        // Try to authorize an un-vetted address
+        const receipt = await route(portfolioContractAccount).doAuthorizeRouter({
             router: addr1.address as `0x${string}`,
         });
         const decodedError = receipt.parseOperationError(factory.interface);
         expect(decodedError?.name).to.equal('RouterNotVetted');
     });
 
-    it('should reject enableRouter from non-factory-principal', async () => {
+    it('should reject authorizeRouter from non-factory-principal', async () => {
         // Deploy and vet a target router
         const RouterContract = await ethers.getContractFactory('RemoteAccountAxelarRouter');
         const targetRouter = await RouterContract.deploy(
@@ -402,8 +402,8 @@ describe('RemoteAccountAxelarRouter - RemoteAccountMulticall', () => {
         await targetRouter.waitForDeployment();
         await factory.getFunction('vetRouter')(targetRouter.target);
 
-        // Try enableRouter from a non-principal source (portfolioLCA resolves to account address, not factory)
-        const receipt = await route(portfolioLCA).doEnableRouter({
+        // Try authorizeRouter from a non-principal source (portfolioLCA resolves to account address, not factory)
+        const receipt = await route(portfolioLCA).doAuthorizeRouter({
             router: targetRouter.target as `0x${string}`,
         });
         const decodedError = receipt.parseOperationError(router.interface);

--- a/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountMulticall.spec.ts
+++ b/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountMulticall.spec.ts
@@ -12,6 +12,7 @@ import {
     computeRemoteAccountAddress,
     deployRemoteAccountFactory,
     ParsedLog,
+    predictDeployAddress,
     routed,
 } from './lib/utils';
 import { multicallAbi } from './interfaces/multicall';
@@ -83,10 +84,14 @@ describe('RemoteAccountAxelarRouter - RemoteAccountMulticall', () => {
         const MockPermit2Factory = await ethers.getContractFactory('MockPermit2');
         permit2Mock = await MockPermit2Factory.deploy();
 
+        // Predict the router address so the factory can enable it at construction
+        const predictedRouterAddress = await predictDeployAddress(owner, 2);
+
         // Deploy RemoteAccount implementation + RemoteAccountFactory
         factory = await deployRemoteAccountFactory(
             portfolioContractCaip2,
             portfolioContractAccount,
+            predictedRouterAddress,
         );
 
         // Deploy RemoteAccountAxelarRouter
@@ -96,14 +101,8 @@ describe('RemoteAccountAxelarRouter - RemoteAccountMulticall', () => {
             sourceChain,
             factory.target,
             permit2Mock.target,
-            owner.address, // ownerAuthority
         );
         await router.waitForDeployment();
-
-        // Vet the router before transferring ownership
-        await factory.vetRouter(router.target);
-
-        await factory.transferOwnership(router.target);
 
         // Deploy Multicall target for tests
         const MulticallFactory = await ethers.getContractFactory('Multicall');
@@ -306,7 +305,7 @@ describe('RemoteAccountAxelarRouter - RemoteAccountMulticall', () => {
         expect(decodedError?.name).to.equal('AddressMismatch');
     });
 
-    it('should transfer factory ownership to vetted router via UpdateOwner', async () => {
+    it('should enable vetted router and allow it to operate accounts', async () => {
         // Deploy a new router
         const RouterContract = await ethers.getContractFactory('RemoteAccountAxelarRouter');
         const newRouter = await RouterContract.deploy(
@@ -314,27 +313,20 @@ describe('RemoteAccountAxelarRouter - RemoteAccountMulticall', () => {
             sourceChain,
             factory.target,
             permit2Mock.target,
-            owner.address,
         );
         await newRouter.waitForDeployment();
 
         // Vet the new router via the current router's owner
-        await router.vetRouter(newRouter.target);
+        await factory.getFunction('vetRouter')(newRouter.target);
 
-        // Verify factory is currently owned by old router
-        expect(await factory.owner()).to.equal(router.target);
-
-        // Transfer factory ownership via UpdateOwner from factory principal
+        // Enable the new router via GMP from factory principal
         (
-            await route(portfolioContractAccount).doUpdateOwner({
-                newOwner: newRouter.target as `0x${string}`,
+            await route(portfolioContractAccount).doEnableRouter({
+                router: newRouter.target as `0x${string}`,
             })
         ).expectOperationSuccess();
 
-        // Verify factory ownership was transferred
-        expect(await factory.owner()).to.equal(newRouter.target);
-
-        // New router (now factory owner) can create and operate accounts
+        // New router can create and operate accounts
         const newRoute = routed(newRouter, routeConfig);
         const newPortfolioLCA = 'agoric1newportfolio123456789abcdefghijk';
 
@@ -344,7 +336,7 @@ describe('RemoteAccountAxelarRouter - RemoteAccountMulticall', () => {
             })
         ).expectOperationSuccess();
 
-        // New router can execute multicalls on existing accounts (O(1) migration)
+        // New router can execute multicalls on existing accounts
         const multiCalls2: ContractCall[] = [multicallContract.setValue(999n)];
         const receipt3 = await newRoute(portfolioLCA).doRemoteAccountExecute({
             multiCalls: multiCalls2,
@@ -352,40 +344,15 @@ describe('RemoteAccountAxelarRouter - RemoteAccountMulticall', () => {
         receipt3.expectOperationSuccess();
         expect(await multicallTarget.getValue()).to.equal(999n);
 
-        // Old router is still enabled (was auto-enabled as previous owner)
-        // It can still operate accounts until explicitly disabled
+        // Old router is still enabled and can still operate alongside new router
         const anotherLCA = 'agoric1anotherportfolio123456789abcdefg';
         const receiptStillEnabled = await route(anotherLCA).doRemoteAccountExecute({
             multiCalls: [],
         });
         receiptStillEnabled.expectOperationSuccess();
-
-        // Disable old router via new router
-        const newRoute2 = routed(newRouter, routeConfig);
-        (
-            await newRoute2(portfolioContractAccount).doDisableRouter({
-                router: router.target as `0x${string}`,
-            })
-        ).expectOperationSuccess();
-
-        // Now old router cannot operate
-        const yetAnotherLCA = 'agoric1yetanotherlca12345678901234abcde';
-        const receiptFail = await route(yetAnotherLCA).doRemoteAccountExecute({
-            multiCalls: [],
-        });
-        const decodedError = receiptFail.parseOperationError(factory.interface);
-        expect(decodedError?.name).to.equal('UnauthorizedCaller');
     });
 
     it('should allow enabled experimental router to operate alongside main router', async () => {
-        // Get current factory owner
-        const currentFactoryOwner = await factory.owner();
-        const currentRouter = await ethers.getContractAt(
-            'RemoteAccountAxelarRouter',
-            currentFactoryOwner,
-        );
-        const currentRoute = routed(currentRouter, routeConfig);
-
         // Deploy experimental router
         const RouterContract = await ethers.getContractFactory('RemoteAccountAxelarRouter');
         const expRouter = await RouterContract.deploy(
@@ -393,14 +360,13 @@ describe('RemoteAccountAxelarRouter - RemoteAccountMulticall', () => {
             sourceChain,
             factory.target,
             permit2Mock.target,
-            owner.address,
         );
         await expRouter.waitForDeployment();
 
         // Vet and enable the experimental router
-        await currentRouter.vetRouter(expRouter.target);
+        await factory.getFunction('vetRouter')(expRouter.target);
         (
-            await currentRoute(portfolioContractAccount).doEnableRouter({
+            await route(portfolioContractAccount).doEnableRouter({
                 router: expRouter.target as `0x${string}`,
             })
         ).expectOperationSuccess();
@@ -414,37 +380,19 @@ describe('RemoteAccountAxelarRouter - RemoteAccountMulticall', () => {
 
         // Main router can also still operate
         const mainLCA = 'agoric1mainroutertest12345678901234abcde';
-        (
-            await currentRoute(mainLCA).doRemoteAccountExecute({ multiCalls: [] })
-        ).expectOperationSuccess();
+        (await route(mainLCA).doRemoteAccountExecute({ multiCalls: [] })).expectOperationSuccess();
     });
 
-    it('should reject UpdateOwner when newOwner is not vetted', async () => {
-        // Get current factory owner
-        const currentFactoryOwner = await factory.owner();
-        const currentRouter = await ethers.getContractAt(
-            'RemoteAccountAxelarRouter',
-            currentFactoryOwner,
-        );
-        const currentRoute = routed(currentRouter, routeConfig);
-
-        // Try to transfer to an un-vetted address
-        const receipt = await currentRoute(portfolioContractAccount).doUpdateOwner({
-            newOwner: addr1.address as `0x${string}`,
+    it('should reject enabling an un-vetted router', async () => {
+        // Try to enable an un-vetted address
+        const receipt = await route(portfolioContractAccount).doEnableRouter({
+            router: addr1.address as `0x${string}`,
         });
         const decodedError = receipt.parseOperationError(factory.interface);
         expect(decodedError?.name).to.equal('RouterNotVetted');
     });
 
-    it('should reject UpdateOwner from non-factory-principal', async () => {
-        // Get current factory owner
-        const currentFactoryOwner = await factory.owner();
-        const currentRouter = await ethers.getContractAt(
-            'RemoteAccountAxelarRouter',
-            currentFactoryOwner,
-        );
-        const currentRoute = routed(currentRouter, routeConfig);
-
+    it('should reject enableRouter from non-factory-principal', async () => {
         // Deploy and vet a target router
         const RouterContract = await ethers.getContractFactory('RemoteAccountAxelarRouter');
         const targetRouter = await RouterContract.deploy(
@@ -452,15 +400,13 @@ describe('RemoteAccountAxelarRouter - RemoteAccountMulticall', () => {
             sourceChain,
             factory.target,
             permit2Mock.target,
-            owner.address,
         );
         await targetRouter.waitForDeployment();
-        await currentRouter.vetRouter(targetRouter.target);
+        await factory.getFunction('vetRouter')(targetRouter.target);
 
-        // Try UpdateOwner from a non-principal source (portfolioLCA resolves to account address, not factory)
-        // The router checks factoryAddress != address(factory), so this should fail with UnauthorizedCaller
-        const receipt = await currentRoute(portfolioLCA).doUpdateOwner({
-            newOwner: targetRouter.target as `0x${string}`,
+        // Try enableRouter from a non-principal source (portfolioLCA resolves to account address, not factory)
+        const receipt = await route(portfolioLCA).doEnableRouter({
+            router: targetRouter.target as `0x${string}`,
         });
         const decodedError = receipt.parseOperationError(router.interface);
         expect(decodedError?.name).to.equal('UnauthorizedCaller');

--- a/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountRouter.spec.ts
+++ b/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountRouter.spec.ts
@@ -6,7 +6,7 @@ import '@nomicfoundation/hardhat-chai-matchers';
 import { HardhatEthersSigner } from '@nomicfoundation/hardhat-ethers/signers';
 import { gmpRouterContract, padTxId, contractWithCallMetadata } from '../utils/router';
 import { makeEvmContract } from '../utils/evm-facade';
-import { routed, deployRemoteAccountFactory, predictDeployAddress } from './lib/utils';
+import { routed, deployRemoteAccountFactory } from './lib/utils';
 import type { ContractCall } from '../interfaces/router';
 import { multicallAbi } from './interfaces/multicall';
 
@@ -53,14 +53,11 @@ describe('RemoteAccountAxelarRouter - RouterBehavior', () => {
         const MockPermit2Factory = await ethers.getContractFactory('MockPermit2');
         permit2Mock = await MockPermit2Factory.deploy();
 
-        // Predict the router address so the factory can enable it at construction
-        const predictedRouterAddress = await predictDeployAddress(owner, 2);
-
         // Deploy RemoteAccount implementation + RemoteAccountFactory
         factory = await deployRemoteAccountFactory(
             portfolioContractCaip2,
             portfolioContractAccount,
-            predictedRouterAddress,
+            owner.address,
         );
 
         const RouterContract = await ethers.getContractFactory('RemoteAccountAxelarRouter');
@@ -71,6 +68,8 @@ describe('RemoteAccountAxelarRouter - RouterBehavior', () => {
             permit2Mock.target,
         );
         await router.waitForDeployment();
+
+        await factory.getFunction('vetInitialRouter')(router.target);
 
         routeConfig = {
             sourceChain,

--- a/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountRouter.spec.ts
+++ b/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountRouter.spec.ts
@@ -69,6 +69,9 @@ describe('RemoteAccountAxelarRouter - RouterBehavior', () => {
         );
         await router.waitForDeployment();
 
+        // Vet the router before transferring ownership
+        await factory.vetRouter(router.target);
+
         await factory.transferOwnership(router.target);
 
         routeConfig = {
@@ -371,15 +374,21 @@ describe('RemoteAccountAxelarRouter - RouterBehavior', () => {
 
     it('should reject direct external call to processUpdateOwnerInstruction', async () => {
         await expect(
-            router.processUpdateOwnerInstruction(portfolioLCA, expectedAccountAddress, {
+            router.processUpdateOwnerInstruction(portfolioLCA, factory.target, {
                 newOwner: addr1.address,
             }),
         ).to.be.reverted;
     });
 
-    it('should reject setSuccessor from non-owner', async () => {
+    it('should reject vetRouter from non-owner', async () => {
         await expect(
-            router.connect(addr1).getFunction('setSuccessor')(addr1.address),
+            router.connect(addr1).getFunction('vetRouter')(addr1.address),
+        ).to.be.revertedWithCustomError(router, 'OwnableUnauthorizedAccount');
+    });
+
+    it('should reject revokeRouter from non-owner', async () => {
+        await expect(
+            router.connect(addr1).getFunction('revokeRouter')(addr1.address),
         ).to.be.revertedWithCustomError(router, 'OwnableUnauthorizedAccount');
     });
 });

--- a/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountRouter.spec.ts
+++ b/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountRouter.spec.ts
@@ -6,7 +6,7 @@ import '@nomicfoundation/hardhat-chai-matchers';
 import { HardhatEthersSigner } from '@nomicfoundation/hardhat-ethers/signers';
 import { gmpRouterContract, padTxId, contractWithCallMetadata } from '../utils/router';
 import { makeEvmContract } from '../utils/evm-facade';
-import { routed, deployRemoteAccountFactory } from './lib/utils';
+import { routed, deployRemoteAccountFactory, predictDeployAddress } from './lib/utils';
 import type { ContractCall } from '../interfaces/router';
 import { multicallAbi } from './interfaces/multicall';
 
@@ -53,10 +53,14 @@ describe('RemoteAccountAxelarRouter - RouterBehavior', () => {
         const MockPermit2Factory = await ethers.getContractFactory('MockPermit2');
         permit2Mock = await MockPermit2Factory.deploy();
 
+        // Predict the router address so the factory can enable it at construction
+        const predictedRouterAddress = await predictDeployAddress(owner, 2);
+
         // Deploy RemoteAccount implementation + RemoteAccountFactory
         factory = await deployRemoteAccountFactory(
             portfolioContractCaip2,
             portfolioContractAccount,
+            predictedRouterAddress,
         );
 
         const RouterContract = await ethers.getContractFactory('RemoteAccountAxelarRouter');
@@ -65,14 +69,8 @@ describe('RemoteAccountAxelarRouter - RouterBehavior', () => {
             sourceChain,
             factory.target,
             permit2Mock.target,
-            owner.address,
         );
         await router.waitForDeployment();
-
-        // Vet the router before transferring ownership
-        await factory.vetRouter(router.target);
-
-        await factory.transferOwnership(router.target);
 
         routeConfig = {
             sourceChain,
@@ -372,10 +370,10 @@ describe('RemoteAccountAxelarRouter - RouterBehavior', () => {
         ).to.be.reverted;
     });
 
-    it('should reject direct external call to processUpdateOwnerInstruction', async () => {
+    it('should reject direct external call to processEnableRouterInstruction', async () => {
         await expect(
-            router.processUpdateOwnerInstruction(portfolioLCA, factory.target, {
-                newOwner: addr1.address,
+            router.processEnableRouterInstruction(portfolioLCA, factory.target, {
+                router: addr1.address,
             }),
         ).to.be.reverted;
     });

--- a/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountRouter.spec.ts
+++ b/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountRouter.spec.ts
@@ -379,16 +379,4 @@ describe('RemoteAccountAxelarRouter - RouterBehavior', () => {
             }),
         ).to.be.reverted;
     });
-
-    it('should reject vetRouter from non-owner', async () => {
-        await expect(
-            router.connect(addr1).getFunction('vetRouter')(addr1.address),
-        ).to.be.revertedWithCustomError(router, 'OwnableUnauthorizedAccount');
-    });
-
-    it('should reject revokeRouter from non-owner', async () => {
-        await expect(
-            router.connect(addr1).getFunction('revokeRouter')(addr1.address),
-        ).to.be.revertedWithCustomError(router, 'OwnableUnauthorizedAccount');
-    });
 });

--- a/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountRouter.spec.ts
+++ b/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountRouter.spec.ts
@@ -369,9 +369,9 @@ describe('RemoteAccountAxelarRouter - RouterBehavior', () => {
         ).to.be.reverted;
     });
 
-    it('should reject direct external call to processEnableRouterInstruction', async () => {
+    it('should reject direct external call to processAuthorizeRouterInstruction', async () => {
         await expect(
-            router.processEnableRouterInstruction(portfolioLCA, factory.target, {
+            router.processAuthorizeRouterInstruction(portfolioLCA, factory.target, {
                 router: addr1.address,
             }),
         ).to.be.reverted;

--- a/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountVetting.spec.ts
+++ b/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountVetting.spec.ts
@@ -114,9 +114,9 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
         ).to.be.revertedWithCustomError(factory, 'UnauthorizedCaller');
     });
 
-    // ==================== Enabling ====================
+    // ==================== Authorization ====================
 
-    it('should enable a vetted router via GMP and emit RouterEnabled', async () => {
+    it('should authorize a vetted router via GMP and emit RouterAuthorized', async () => {
         const RouterContract = await ethers.getContractFactory('RemoteAccountAxelarRouter');
         const newRouter = await RouterContract.deploy(
             axelarGatewayMock.target,
@@ -135,8 +135,8 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
             initialAuthorizedRouters,
         );
 
-        // Enable via GMP from factory principal
-        const receipt = await route(portfolioContractAccount).doEnableRouter({
+        // Authorize via GMP from factory principal
+        const receipt = await route(portfolioContractAccount).doAuthorizeRouter({
             router: newRouter.target as `0x${string}`,
         });
         receipt.expectOperationSuccess();
@@ -148,17 +148,17 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
         );
     });
 
-    it('should reject enabling an un-vetted router', async () => {
+    it('should reject authorizing an un-vetted router', async () => {
         const unvetted = addr1.address;
 
-        const receipt = await route(portfolioContractAccount).doEnableRouter({
+        const receipt = await route(portfolioContractAccount).doAuthorizeRouter({
             router: unvetted as `0x${string}`,
         });
         const decodedError = receipt.parseOperationError(factory.interface);
         expect(decodedError?.name).to.equal('RouterNotVetted');
     });
 
-    it('should reject enableRouter from non-factory-principal', async () => {
+    it('should reject authorizeRouter from non-factory-principal', async () => {
         const RouterContract = await ethers.getContractFactory('RemoteAccountAxelarRouter');
         const newRouter = await RouterContract.deploy(
             axelarGatewayMock.target,
@@ -172,16 +172,16 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
         // Non-principal LCA resolves to a remote account address (not factory),
         // so the router rejects with UnauthorizedCaller before reaching the principal check
         const nonPrincipalLCA = 'agoric1notprincipal12345678901234abcde';
-        const receipt = await route(nonPrincipalLCA).doEnableRouter({
+        const receipt = await route(nonPrincipalLCA).doAuthorizeRouter({
             router: newRouter.target as `0x${string}`,
         });
         const decodedError = receipt.parseOperationError(router.interface);
         expect(decodedError?.name).to.equal('UnauthorizedCaller');
     });
 
-    // ==================== Disabling ====================
+    // ==================== Deauthorization ====================
 
-    it('should disable an enabled router via GMP', async () => {
+    it('should deauthorize an authorized router via GMP', async () => {
         const RouterContract = await ethers.getContractFactory('RemoteAccountAxelarRouter');
         const newRouter = await RouterContract.deploy(
             axelarGatewayMock.target,
@@ -193,10 +193,10 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
 
         const initialAuthorizedRouters = await factory.getFunction('numberOfAuthorizedRouters')();
 
-        // Vet and enable
+        // Vet and authorize
         await factory.getFunction('vetRouter')(newRouter.target);
         (
-            await route(portfolioContractAccount).doEnableRouter({
+            await route(portfolioContractAccount).doAuthorizeRouter({
                 router: newRouter.target as `0x${string}`,
             })
         ).expectOperationSuccess();
@@ -205,8 +205,8 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
             initialAuthorizedRouters + 1n,
         );
 
-        // Disable via GMP
-        const receipt = await route(portfolioContractAccount).doDisableRouter({
+        // Deauthorize via GMP
+        const receipt = await route(portfolioContractAccount).doDeauthorizeRouter({
             router: newRouter.target as `0x${string}`,
         });
         receipt.expectOperationSuccess();
@@ -218,20 +218,20 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
         );
     });
 
-    it('should reject disableRouter from non-factory-principal', async () => {
+    it('should reject deauthorizeRouter from non-factory-principal', async () => {
         // Non-principal LCA resolves to a remote account address (not factory),
         // so the router rejects with UnauthorizedCaller
         const nonPrincipalLCA = 'agoric1notprincipal12345678901234abcde';
-        const receipt = await route(nonPrincipalLCA).doDisableRouter({
+        const receipt = await route(nonPrincipalLCA).doDeauthorizeRouter({
             router: addr1.address as `0x${string}`,
         });
         const decodedError = receipt.parseOperationError(router.interface);
         expect(decodedError?.name).to.equal('UnauthorizedCaller');
     });
 
-    // ==================== Revoking ====================
+    // ==================== Unvetting ====================
 
-    it('should revoke a disabled router and keep vet / enable / disable / revoke idempotent', async () => {
+    it('should unvet a deauthorized router and keep vet / authorize / deauthorize / unvet idempotent', async () => {
         const RouterContract = await ethers.getContractFactory('RemoteAccountAxelarRouter');
         const newRouter = await RouterContract.deploy(
             axelarGatewayMock.target,
@@ -258,9 +258,9 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
             initialAuthorizedRouters,
         );
 
-        // Enable is idempotent
+        // Authorize is idempotent
         (
-            await route(portfolioContractAccount).doEnableRouter({
+            await route(portfolioContractAccount).doAuthorizeRouter({
                 router: newRouter.target as `0x${string}`,
             })
         ).expectOperationSuccess();
@@ -270,7 +270,7 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
         );
 
         (
-            await route(portfolioContractAccount).doEnableRouter({
+            await route(portfolioContractAccount).doAuthorizeRouter({
                 router: newRouter.target as `0x${string}`,
             })
         ).expectOperationSuccess();
@@ -279,9 +279,9 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
             initialAuthorizedRouters + 1n,
         );
 
-        // Disable is idempotent
+        // Deauthorize is idempotent
         (
-            await route(portfolioContractAccount).doDisableRouter({
+            await route(portfolioContractAccount).doDeauthorizeRouter({
                 router: newRouter.target as `0x${string}`,
             })
         ).expectOperationSuccess();
@@ -291,7 +291,7 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
         );
 
         (
-            await route(portfolioContractAccount).doDisableRouter({
+            await route(portfolioContractAccount).doDeauthorizeRouter({
                 router: newRouter.target as `0x${string}`,
             })
         ).expectOperationSuccess();
@@ -300,23 +300,23 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
             initialAuthorizedRouters,
         );
 
-        // Revoke is idempotent
-        await expect(factory.getFunction('revokeRouter')(newRouter.target))
-            .to.emit(factory, 'RouterRevoked')
+        // Unvet is idempotent
+        await expect(factory.getFunction('unvetRouter')(newRouter.target))
+            .to.emit(factory, 'RouterUnvetted')
             .withArgs(newRouter.target);
         expect(await factory.getFunction('isAuthorizedRouter')(newRouter.target)).to.equal(false);
         expect(await factory.getFunction('numberOfAuthorizedRouters')()).to.equal(
             initialAuthorizedRouters,
         );
 
-        await factory.getFunction('revokeRouter')(newRouter.target);
+        await factory.getFunction('unvetRouter')(newRouter.target);
         expect(await factory.getFunction('isAuthorizedRouter')(newRouter.target)).to.equal(false);
         expect(await factory.getFunction('numberOfAuthorizedRouters')()).to.equal(
             initialAuthorizedRouters,
         );
     });
 
-    it('should reject revoking a router that is still enabled', async () => {
+    it('should reject unvetting a router that is still authorized', async () => {
         const RouterContract = await ethers.getContractFactory('RemoteAccountAxelarRouter');
         const newRouter = await RouterContract.deploy(
             axelarGatewayMock.target,
@@ -326,23 +326,23 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
         );
         await newRouter.waitForDeployment();
 
-        // Vet and enable
+        // Vet and authorize
         await factory.getFunction('vetRouter')(newRouter.target);
         (
-            await route(portfolioContractAccount).doEnableRouter({
+            await route(portfolioContractAccount).doAuthorizeRouter({
                 router: newRouter.target as `0x${string}`,
             })
         ).expectOperationSuccess();
 
-        // Try to revoke without disabling first
+        // Try to unvet without deauthorizing first
         await expect(
-            factory.getFunction('revokeRouter')(newRouter.target),
+            factory.getFunction('unvetRouter')(newRouter.target),
         ).to.be.revertedWithCustomError(factory, 'RouterNotVetted');
     });
 
-    it('should reject revokeRouter from non-vetting-authority', async () => {
+    it('should reject unvetRouter from non-vetting-authority', async () => {
         await expect(
-            factory.connect(addr1).getFunction('revokeRouter')(addr1.address),
+            factory.connect(addr1).getFunction('unvetRouter')(addr1.address),
         ).to.be.revertedWithCustomError(factory, 'UnauthorizedCaller');
     });
 
@@ -356,7 +356,7 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
         expect(await factory.getFunction('isAuthorizedRouter')(addr1.address)).to.equal(false);
     });
 
-    it('should return true for enabled router and false after disabling', async () => {
+    it('should return true for authorized router and false after deauthorizing', async () => {
         const RouterContract = await ethers.getContractFactory('RemoteAccountAxelarRouter');
         const newRouter = await RouterContract.deploy(
             axelarGatewayMock.target,
@@ -373,17 +373,17 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
         await factory.getFunction('vetRouter')(newRouter.target);
         expect(await factory.getFunction('isAuthorizedRouter')(newRouter.target)).to.equal(false);
 
-        // Enable — now authorized
+        // Authorize — now authorized
         (
-            await route(portfolioContractAccount).doEnableRouter({
+            await route(portfolioContractAccount).doAuthorizeRouter({
                 router: newRouter.target as `0x${string}`,
             })
         ).expectOperationSuccess();
         expect(await factory.getFunction('isAuthorizedRouter')(newRouter.target)).to.equal(true);
 
-        // Disable — no longer authorized
+        // Deauthorize — no longer authorized
         (
-            await route(portfolioContractAccount).doDisableRouter({
+            await route(portfolioContractAccount).doDeauthorizeRouter({
                 router: newRouter.target as `0x${string}`,
             })
         ).expectOperationSuccess();
@@ -392,7 +392,7 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
 
     // ==================== Full lifecycle ====================
 
-    it('should support full vet → enable → operate → disable → revoke lifecycle', async () => {
+    it('should support full vet → authorize → operate → deauthorize → unvet lifecycle', async () => {
         const RouterContract = await ethers.getContractFactory('RemoteAccountAxelarRouter');
         const expRouter = await RouterContract.deploy(
             axelarGatewayMock.target,
@@ -405,9 +405,9 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
         // 1. Vet (vetting authority)
         await factory.getFunction('vetRouter')(expRouter.target);
 
-        // 2. Enable (Agoric chain via GMP)
+        // 2. Authorize (Agoric chain via GMP)
         (
-            await route(portfolioContractAccount).doEnableRouter({
+            await route(portfolioContractAccount).doAuthorizeRouter({
                 router: expRouter.target as `0x${string}`,
             })
         ).expectOperationSuccess();
@@ -417,9 +417,9 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
         const lca = 'agoric1lifecycletest12345678901234abcde';
         (await expRoute(lca).doRemoteAccountExecute({ multiCalls: [] })).expectOperationSuccess();
 
-        // 4. Disable (Agoric chain via GMP)
+        // 4. Deauthorize (Agoric chain via GMP)
         (
-            await route(portfolioContractAccount).doDisableRouter({
+            await route(portfolioContractAccount).doDeauthorizeRouter({
                 router: expRouter.target as `0x${string}`,
             })
         ).expectOperationSuccess();
@@ -435,15 +435,15 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
         const decodedError = failReceipt.parseOperationError(factory.interface);
         expect(decodedError?.name).to.equal('UnauthorizedCaller');
 
-        // 5. Revoke (vetting authority)
-        await factory.getFunction('revokeRouter')(expRouter.target);
+        // 5. Unvet (vetting authority)
+        await factory.getFunction('unvetRouter')(expRouter.target);
 
-        // Cannot re-enable without vetting again
-        const reEnableReceipt = await route(portfolioContractAccount).doEnableRouter({
+        // Cannot re-authorize without vetting again
+        const reAuthorizeReceipt = await route(portfolioContractAccount).doAuthorizeRouter({
             router: expRouter.target as `0x${string}`,
         });
-        const reEnableError = reEnableReceipt.parseOperationError(factory.interface);
-        expect(reEnableError?.name).to.equal('RouterNotVetted');
+        const reAuthorizeError = reAuthorizeReceipt.parseOperationError(factory.interface);
+        expect(reAuthorizeError?.name).to.equal('RouterNotVetted');
     });
 
     // ==================== Vetting Authority Transfer ====================

--- a/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountVetting.spec.ts
+++ b/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountVetting.spec.ts
@@ -126,9 +126,14 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
         );
         await newRouter.waitForDeployment();
 
+        const initialAuthorizedRouters = await factory.getFunction('numberOfAuthorizedRouters')();
+
         // Vet first
         await factory.getFunction('vetRouter')(newRouter.target);
         expect(await factory.getFunction('isAuthorizedRouter')(newRouter.target)).to.equal(false);
+        expect(await factory.getFunction('numberOfAuthorizedRouters')()).to.equal(
+            initialAuthorizedRouters,
+        );
 
         // Enable via GMP from factory principal
         const receipt = await route(portfolioContractAccount).doEnableRouter({
@@ -138,6 +143,9 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
 
         // Now authorized
         expect(await factory.getFunction('isAuthorizedRouter')(newRouter.target)).to.equal(true);
+        expect(await factory.getFunction('numberOfAuthorizedRouters')()).to.equal(
+            initialAuthorizedRouters + 1n,
+        );
     });
 
     it('should reject enabling an un-vetted router', async () => {
@@ -183,6 +191,8 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
         );
         await newRouter.waitForDeployment();
 
+        const initialAuthorizedRouters = await factory.getFunction('numberOfAuthorizedRouters')();
+
         // Vet and enable
         await factory.getFunction('vetRouter')(newRouter.target);
         (
@@ -191,6 +201,9 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
             })
         ).expectOperationSuccess();
         expect(await factory.getFunction('isAuthorizedRouter')(newRouter.target)).to.equal(true);
+        expect(await factory.getFunction('numberOfAuthorizedRouters')()).to.equal(
+            initialAuthorizedRouters + 1n,
+        );
 
         // Disable via GMP
         const receipt = await route(portfolioContractAccount).doDisableRouter({
@@ -200,6 +213,9 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
 
         // No longer authorized
         expect(await factory.getFunction('isAuthorizedRouter')(newRouter.target)).to.equal(false);
+        expect(await factory.getFunction('numberOfAuthorizedRouters')()).to.equal(
+            initialAuthorizedRouters,
+        );
     });
 
     it('should reject disableRouter from non-factory-principal', async () => {
@@ -215,7 +231,7 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
 
     // ==================== Revoking ====================
 
-    it('should revoke a disabled router and emit RouterRevoked', async () => {
+    it('should revoke a disabled router and keep vet / enable / disable / revoke idempotent', async () => {
         const RouterContract = await ethers.getContractFactory('RemoteAccountAxelarRouter');
         const newRouter = await RouterContract.deploy(
             axelarGatewayMock.target,
@@ -225,23 +241,79 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
         );
         await newRouter.waitForDeployment();
 
-        // Vet, enable, then disable
+        const initialAuthorizedRouters = await factory.getFunction('numberOfAuthorizedRouters')();
+
+        // Vet is idempotent
+        await expect(factory.getFunction('vetRouter')(newRouter.target))
+            .to.emit(factory, 'RouterVetted')
+            .withArgs(newRouter.target);
+        expect(await factory.getFunction('isAuthorizedRouter')(newRouter.target)).to.equal(false);
+        expect(await factory.getFunction('numberOfAuthorizedRouters')()).to.equal(
+            initialAuthorizedRouters,
+        );
+
         await factory.getFunction('vetRouter')(newRouter.target);
+        expect(await factory.getFunction('isAuthorizedRouter')(newRouter.target)).to.equal(false);
+        expect(await factory.getFunction('numberOfAuthorizedRouters')()).to.equal(
+            initialAuthorizedRouters,
+        );
+
+        // Enable is idempotent
         (
             await route(portfolioContractAccount).doEnableRouter({
                 router: newRouter.target as `0x${string}`,
             })
         ).expectOperationSuccess();
+        expect(await factory.getFunction('isAuthorizedRouter')(newRouter.target)).to.equal(true);
+        expect(await factory.getFunction('numberOfAuthorizedRouters')()).to.equal(
+            initialAuthorizedRouters + 1n,
+        );
+
+        (
+            await route(portfolioContractAccount).doEnableRouter({
+                router: newRouter.target as `0x${string}`,
+            })
+        ).expectOperationSuccess();
+        expect(await factory.getFunction('isAuthorizedRouter')(newRouter.target)).to.equal(true);
+        expect(await factory.getFunction('numberOfAuthorizedRouters')()).to.equal(
+            initialAuthorizedRouters + 1n,
+        );
+
+        // Disable is idempotent
         (
             await route(portfolioContractAccount).doDisableRouter({
                 router: newRouter.target as `0x${string}`,
             })
         ).expectOperationSuccess();
+        expect(await factory.getFunction('isAuthorizedRouter')(newRouter.target)).to.equal(false);
+        expect(await factory.getFunction('numberOfAuthorizedRouters')()).to.equal(
+            initialAuthorizedRouters,
+        );
 
-        // Revoke
+        (
+            await route(portfolioContractAccount).doDisableRouter({
+                router: newRouter.target as `0x${string}`,
+            })
+        ).expectOperationSuccess();
+        expect(await factory.getFunction('isAuthorizedRouter')(newRouter.target)).to.equal(false);
+        expect(await factory.getFunction('numberOfAuthorizedRouters')()).to.equal(
+            initialAuthorizedRouters,
+        );
+
+        // Revoke is idempotent
         await expect(factory.getFunction('revokeRouter')(newRouter.target))
             .to.emit(factory, 'RouterRevoked')
             .withArgs(newRouter.target);
+        expect(await factory.getFunction('isAuthorizedRouter')(newRouter.target)).to.equal(false);
+        expect(await factory.getFunction('numberOfAuthorizedRouters')()).to.equal(
+            initialAuthorizedRouters,
+        );
+
+        await factory.getFunction('revokeRouter')(newRouter.target);
+        expect(await factory.getFunction('isAuthorizedRouter')(newRouter.target)).to.equal(false);
+        expect(await factory.getFunction('numberOfAuthorizedRouters')()).to.equal(
+            initialAuthorizedRouters,
+        );
     });
 
     it('should reject revoking a router that is still enabled', async () => {

--- a/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountVetting.spec.ts
+++ b/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountVetting.spec.ts
@@ -1,0 +1,365 @@
+import AxelarGasService from '@axelar-network/axelar-cgp-solidity/artifacts/contracts/gas-service/AxelarGasService.sol/AxelarGasService.json';
+import { expect } from 'chai';
+import { Contract } from 'ethers';
+import { ethers } from 'hardhat';
+import '@nomicfoundation/hardhat-chai-matchers';
+import { HardhatEthersSigner } from '@nomicfoundation/hardhat-ethers/signers';
+import { routed, deployRemoteAccountFactory } from './lib/utils';
+
+describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
+    let owner: HardhatEthersSigner, addr1: HardhatEthersSigner;
+    let axelarGatewayMock: Contract;
+    let factory: Contract, router: Contract, permit2Mock: Contract;
+
+    const abiCoder = new ethers.AbiCoder();
+
+    const sourceChain = 'agoric';
+    const portfolioContractCaip2 = 'cosmos:agoric-3';
+    const portfolioContractAccount = 'agoric1routerlca123456789abcdefghijklmnopqrs';
+
+    let route: ReturnType<typeof routed>;
+    let routeConfig: Parameters<typeof routed>[1];
+
+    before(async () => {
+        [owner, addr1] = await ethers.getSigners();
+
+        const GasServiceFactory = await ethers.getContractFactory(
+            AxelarGasService.abi,
+            AxelarGasService.bytecode,
+        );
+        await GasServiceFactory.deploy(owner.address);
+
+        const TokenDeployerFactory = await ethers.getContractFactory('TokenDeployer');
+        const tokenDeployer = await TokenDeployerFactory.deploy();
+
+        const AuthFactory = await ethers.getContractFactory('AxelarAuthWeighted');
+        const authContract = await AuthFactory.deploy([
+            abiCoder.encode(['address[]', 'uint256[]', 'uint256'], [[owner.address], [1], 1]),
+        ]);
+
+        const AxelarGatewayFactory = await ethers.getContractFactory('AxelarGateway');
+        axelarGatewayMock = await AxelarGatewayFactory.deploy(
+            authContract.target,
+            tokenDeployer.target,
+        );
+
+        const MockPermit2Factory = await ethers.getContractFactory('MockPermit2');
+        permit2Mock = await MockPermit2Factory.deploy();
+
+        factory = await deployRemoteAccountFactory(
+            portfolioContractCaip2,
+            portfolioContractAccount,
+        );
+
+        const RouterContract = await ethers.getContractFactory('RemoteAccountAxelarRouter');
+        router = await RouterContract.deploy(
+            axelarGatewayMock.target,
+            sourceChain,
+            factory.target,
+            permit2Mock.target,
+            owner.address,
+        );
+        await router.waitForDeployment();
+
+        await factory.getFunction('vetRouter')(router.target);
+        await factory.getFunction('transferOwnership')(router.target);
+
+        routeConfig = {
+            sourceChain,
+            owner,
+            portfolioContractAccount,
+            AxelarGateway: axelarGatewayMock,
+            abiCoder,
+        };
+        route = routed(router, routeConfig);
+    });
+
+    // ==================== Vetting ====================
+
+    it('should vet a router and emit RouterVetted event', async () => {
+        const RouterContract = await ethers.getContractFactory('RemoteAccountAxelarRouter');
+        const newRouter = await RouterContract.deploy(
+            axelarGatewayMock.target,
+            sourceChain,
+            factory.target,
+            permit2Mock.target,
+            owner.address,
+        );
+        await newRouter.waitForDeployment();
+
+        await expect(router.getFunction('vetRouter')(newRouter.target))
+            .to.emit(router, 'RouterVetted')
+            .withArgs(newRouter.target);
+
+        // Vetted but not yet enabled — not authorized
+        expect(await factory.getFunction('isAuthorizedCaller')(newRouter.target)).to.equal(false);
+    });
+
+    it('should reject vetRouter from non-owner', async () => {
+        await expect(
+            router.connect(addr1).getFunction('vetRouter')(addr1.address),
+        ).to.be.revertedWithCustomError(router, 'OwnableUnauthorizedAccount');
+    });
+
+    // ==================== Enabling ====================
+
+    it('should enable a vetted router via GMP and emit RouterEnabled', async () => {
+        const RouterContract = await ethers.getContractFactory('RemoteAccountAxelarRouter');
+        const newRouter = await RouterContract.deploy(
+            axelarGatewayMock.target,
+            sourceChain,
+            factory.target,
+            permit2Mock.target,
+            owner.address,
+        );
+        await newRouter.waitForDeployment();
+
+        // Vet first
+        await router.getFunction('vetRouter')(newRouter.target);
+        expect(await factory.getFunction('isAuthorizedCaller')(newRouter.target)).to.equal(false);
+
+        // Enable via GMP from factory principal
+        const receipt = await route(portfolioContractAccount).doEnableRouter({
+            router: newRouter.target as `0x${string}`,
+        });
+        receipt.expectOperationSuccess();
+
+        // Now authorized
+        expect(await factory.getFunction('isAuthorizedCaller')(newRouter.target)).to.equal(true);
+    });
+
+    it('should reject enabling an un-vetted router', async () => {
+        const unvetted = addr1.address;
+
+        const receipt = await route(portfolioContractAccount).doEnableRouter({
+            router: unvetted as `0x${string}`,
+        });
+        const decodedError = receipt.parseOperationError(factory.interface);
+        expect(decodedError?.name).to.equal('RouterNotVetted');
+    });
+
+    it('should reject enableRouter from non-factory-principal', async () => {
+        const RouterContract = await ethers.getContractFactory('RemoteAccountAxelarRouter');
+        const newRouter = await RouterContract.deploy(
+            axelarGatewayMock.target,
+            sourceChain,
+            factory.target,
+            permit2Mock.target,
+            owner.address,
+        );
+        await newRouter.waitForDeployment();
+        await router.getFunction('vetRouter')(newRouter.target);
+
+        // Non-principal LCA resolves to a remote account address (not factory),
+        // so the router rejects with UnauthorizedCaller before reaching the principal check
+        const nonPrincipalLCA = 'agoric1notprincipal12345678901234abcde';
+        const receipt = await route(nonPrincipalLCA).doEnableRouter({
+            router: newRouter.target as `0x${string}`,
+        });
+        const decodedError = receipt.parseOperationError(router.interface);
+        expect(decodedError?.name).to.equal('UnauthorizedCaller');
+    });
+
+    // ==================== Disabling ====================
+
+    it('should disable an enabled router via GMP', async () => {
+        const RouterContract = await ethers.getContractFactory('RemoteAccountAxelarRouter');
+        const newRouter = await RouterContract.deploy(
+            axelarGatewayMock.target,
+            sourceChain,
+            factory.target,
+            permit2Mock.target,
+            owner.address,
+        );
+        await newRouter.waitForDeployment();
+
+        // Vet and enable
+        await router.getFunction('vetRouter')(newRouter.target);
+        (
+            await route(portfolioContractAccount).doEnableRouter({
+                router: newRouter.target as `0x${string}`,
+            })
+        ).expectOperationSuccess();
+        expect(await factory.getFunction('isAuthorizedCaller')(newRouter.target)).to.equal(true);
+
+        // Disable via GMP
+        const receipt = await route(portfolioContractAccount).doDisableRouter({
+            router: newRouter.target as `0x${string}`,
+        });
+        receipt.expectOperationSuccess();
+
+        // No longer authorized
+        expect(await factory.getFunction('isAuthorizedCaller')(newRouter.target)).to.equal(false);
+    });
+
+    it('should reject disableRouter from non-factory-principal', async () => {
+        // Non-principal LCA resolves to a remote account address (not factory),
+        // so the router rejects with UnauthorizedCaller
+        const nonPrincipalLCA = 'agoric1notprincipal12345678901234abcde';
+        const receipt = await route(nonPrincipalLCA).doDisableRouter({
+            router: addr1.address as `0x${string}`,
+        });
+        const decodedError = receipt.parseOperationError(router.interface);
+        expect(decodedError?.name).to.equal('UnauthorizedCaller');
+    });
+
+    // ==================== Revoking ====================
+
+    it('should revoke a disabled router and emit RouterRevoked', async () => {
+        const RouterContract = await ethers.getContractFactory('RemoteAccountAxelarRouter');
+        const newRouter = await RouterContract.deploy(
+            axelarGatewayMock.target,
+            sourceChain,
+            factory.target,
+            permit2Mock.target,
+            owner.address,
+        );
+        await newRouter.waitForDeployment();
+
+        // Vet, enable, then disable
+        await router.getFunction('vetRouter')(newRouter.target);
+        (
+            await route(portfolioContractAccount).doEnableRouter({
+                router: newRouter.target as `0x${string}`,
+            })
+        ).expectOperationSuccess();
+        (
+            await route(portfolioContractAccount).doDisableRouter({
+                router: newRouter.target as `0x${string}`,
+            })
+        ).expectOperationSuccess();
+
+        // Revoke
+        await expect(router.getFunction('revokeRouter')(newRouter.target))
+            .to.emit(router, 'RouterRevoked')
+            .withArgs(newRouter.target);
+    });
+
+    it('should reject revoking a router that is still enabled', async () => {
+        const RouterContract = await ethers.getContractFactory('RemoteAccountAxelarRouter');
+        const newRouter = await RouterContract.deploy(
+            axelarGatewayMock.target,
+            sourceChain,
+            factory.target,
+            permit2Mock.target,
+            owner.address,
+        );
+        await newRouter.waitForDeployment();
+
+        // Vet and enable
+        await router.getFunction('vetRouter')(newRouter.target);
+        (
+            await route(portfolioContractAccount).doEnableRouter({
+                router: newRouter.target as `0x${string}`,
+            })
+        ).expectOperationSuccess();
+
+        // Try to revoke without disabling first
+        await expect(
+            router.getFunction('revokeRouter')(newRouter.target),
+        ).to.be.revertedWithCustomError(factory, 'RouterStillEnabled');
+    });
+
+    it('should reject revokeRouter from non-owner', async () => {
+        await expect(
+            router.connect(addr1).getFunction('revokeRouter')(addr1.address),
+        ).to.be.revertedWithCustomError(router, 'OwnableUnauthorizedAccount');
+    });
+
+    // ==================== isAuthorizedCaller ====================
+
+    it('should return true for factory owner', async () => {
+        expect(await factory.getFunction('isAuthorizedCaller')(router.target)).to.equal(true);
+    });
+
+    it('should return false for random address', async () => {
+        expect(await factory.getFunction('isAuthorizedCaller')(addr1.address)).to.equal(false);
+    });
+
+    it('should return true for enabled router and false after disabling', async () => {
+        const RouterContract = await ethers.getContractFactory('RemoteAccountAxelarRouter');
+        const newRouter = await RouterContract.deploy(
+            axelarGatewayMock.target,
+            sourceChain,
+            factory.target,
+            permit2Mock.target,
+            owner.address,
+        );
+        await newRouter.waitForDeployment();
+
+        // Not authorized initially
+        expect(await factory.getFunction('isAuthorizedCaller')(newRouter.target)).to.equal(false);
+
+        // Vet — still not authorized
+        await router.getFunction('vetRouter')(newRouter.target);
+        expect(await factory.getFunction('isAuthorizedCaller')(newRouter.target)).to.equal(false);
+
+        // Enable — now authorized
+        (
+            await route(portfolioContractAccount).doEnableRouter({
+                router: newRouter.target as `0x${string}`,
+            })
+        ).expectOperationSuccess();
+        expect(await factory.getFunction('isAuthorizedCaller')(newRouter.target)).to.equal(true);
+
+        // Disable — no longer authorized
+        (
+            await route(portfolioContractAccount).doDisableRouter({
+                router: newRouter.target as `0x${string}`,
+            })
+        ).expectOperationSuccess();
+        expect(await factory.getFunction('isAuthorizedCaller')(newRouter.target)).to.equal(false);
+    });
+
+    // ==================== Full lifecycle ====================
+
+    it('should support full vet → enable → operate → disable → revoke lifecycle', async () => {
+        const RouterContract = await ethers.getContractFactory('RemoteAccountAxelarRouter');
+        const expRouter = await RouterContract.deploy(
+            axelarGatewayMock.target,
+            sourceChain,
+            factory.target,
+            permit2Mock.target,
+            owner.address,
+        );
+        await expRouter.waitForDeployment();
+
+        // 1. Vet (off-chain admin)
+        await router.getFunction('vetRouter')(expRouter.target);
+
+        // 2. Enable (Agoric chain via GMP)
+        (
+            await route(portfolioContractAccount).doEnableRouter({
+                router: expRouter.target as `0x${string}`,
+            })
+        ).expectOperationSuccess();
+
+        // 3. Operate — experimental router can create and use accounts
+        const expRoute = routed(expRouter, routeConfig);
+        const lca = 'agoric1lifecycletest12345678901234abcde';
+        (await expRoute(lca).doRemoteAccountExecute({ multiCalls: [] })).expectOperationSuccess();
+
+        // 4. Disable (Agoric chain via GMP)
+        (
+            await route(portfolioContractAccount).doDisableRouter({
+                router: expRouter.target as `0x${string}`,
+            })
+        ).expectOperationSuccess();
+
+        // Experimental router can no longer operate
+        const lca2 = 'agoric1lifecycletest2345678901234abcdef';
+        const failReceipt = await expRoute(lca2).doRemoteAccountExecute({ multiCalls: [] });
+        const decodedError = failReceipt.parseOperationError(factory.interface);
+        expect(decodedError?.name).to.equal('UnauthorizedCaller');
+
+        // 5. Revoke (off-chain admin)
+        await router.getFunction('revokeRouter')(expRouter.target);
+
+        // Cannot re-enable without vetting again
+        const reEnableReceipt = await route(portfolioContractAccount).doEnableRouter({
+            router: expRouter.target as `0x${string}`,
+        });
+        const reEnableError = reEnableReceipt.parseOperationError(factory.interface);
+        expect(reEnableError?.name).to.equal('RouterNotVetted');
+    });
+});

--- a/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountVetting.spec.ts
+++ b/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountVetting.spec.ts
@@ -4,7 +4,6 @@ import { Contract } from 'ethers';
 import { ethers } from 'hardhat';
 import '@nomicfoundation/hardhat-chai-matchers';
 import { HardhatEthersSigner } from '@nomicfoundation/hardhat-ethers/signers';
-import * as helpers from '@nomicfoundation/hardhat-network-helpers';
 import { routed, deployRemoteAccountFactory, predictDeployAddress } from './lib/utils';
 
 describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
@@ -87,18 +86,18 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
         );
         await newRouter.waitForDeployment();
 
-        await expect(router.getFunction('vetRouter')(newRouter.target))
-            .to.emit(router, 'RouterVetted')
+        await expect(factory.getFunction('vetRouter')(newRouter.target))
+            .to.emit(factory, 'RouterVetted')
             .withArgs(newRouter.target);
 
         // Vetted but not yet enabled — not authorized
         expect(await factory.getFunction('isAuthorizedRouter')(newRouter.target)).to.equal(false);
     });
 
-    it('should reject vetRouter from non-owner', async () => {
+    it('should reject vetRouter from non-vetting-authority', async () => {
         await expect(
-            router.connect(addr1).getFunction('vetRouter')(addr1.address),
-        ).to.be.revertedWithCustomError(router, 'OwnableUnauthorizedAccount');
+            factory.connect(addr1).getFunction('vetRouter')(addr1.address),
+        ).to.be.revertedWithCustomError(factory, 'UnauthorizedCaller');
     });
 
     // ==================== Enabling ====================
@@ -114,7 +113,7 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
         await newRouter.waitForDeployment();
 
         // Vet first
-        await router.getFunction('vetRouter')(newRouter.target);
+        await factory.getFunction('vetRouter')(newRouter.target);
         expect(await factory.getFunction('isAuthorizedRouter')(newRouter.target)).to.equal(false);
 
         // Enable via GMP from factory principal
@@ -146,7 +145,7 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
             permit2Mock.target,
         );
         await newRouter.waitForDeployment();
-        await router.getFunction('vetRouter')(newRouter.target);
+        await factory.getFunction('vetRouter')(newRouter.target);
 
         // Non-principal LCA resolves to a remote account address (not factory),
         // so the router rejects with UnauthorizedCaller before reaching the principal check
@@ -171,7 +170,7 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
         await newRouter.waitForDeployment();
 
         // Vet and enable
-        await router.getFunction('vetRouter')(newRouter.target);
+        await factory.getFunction('vetRouter')(newRouter.target);
         (
             await route(portfolioContractAccount).doEnableRouter({
                 router: newRouter.target as `0x${string}`,
@@ -213,7 +212,7 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
         await newRouter.waitForDeployment();
 
         // Vet, enable, then disable
-        await router.getFunction('vetRouter')(newRouter.target);
+        await factory.getFunction('vetRouter')(newRouter.target);
         (
             await route(portfolioContractAccount).doEnableRouter({
                 router: newRouter.target as `0x${string}`,
@@ -226,8 +225,8 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
         ).expectOperationSuccess();
 
         // Revoke
-        await expect(router.getFunction('revokeRouter')(newRouter.target))
-            .to.emit(router, 'RouterRevoked')
+        await expect(factory.getFunction('revokeRouter')(newRouter.target))
+            .to.emit(factory, 'RouterRevoked')
             .withArgs(newRouter.target);
     });
 
@@ -242,7 +241,7 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
         await newRouter.waitForDeployment();
 
         // Vet and enable
-        await router.getFunction('vetRouter')(newRouter.target);
+        await factory.getFunction('vetRouter')(newRouter.target);
         (
             await route(portfolioContractAccount).doEnableRouter({
                 router: newRouter.target as `0x${string}`,
@@ -251,14 +250,14 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
 
         // Try to revoke without disabling first
         await expect(
-            router.getFunction('revokeRouter')(newRouter.target),
-        ).to.be.revertedWithCustomError(factory, 'RouterStillEnabled');
+            factory.getFunction('revokeRouter')(newRouter.target),
+        ).to.be.revertedWithCustomError(factory, 'RouterNotVetted');
     });
 
-    it('should reject revokeRouter from non-owner', async () => {
+    it('should reject revokeRouter from non-vetting-authority', async () => {
         await expect(
-            router.connect(addr1).getFunction('revokeRouter')(addr1.address),
-        ).to.be.revertedWithCustomError(router, 'OwnableUnauthorizedAccount');
+            factory.connect(addr1).getFunction('revokeRouter')(addr1.address),
+        ).to.be.revertedWithCustomError(factory, 'UnauthorizedCaller');
     });
 
     // ==================== isAuthorizedRouter ====================
@@ -285,7 +284,7 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
         expect(await factory.getFunction('isAuthorizedRouter')(newRouter.target)).to.equal(false);
 
         // Vet — still not authorized
-        await router.getFunction('vetRouter')(newRouter.target);
+        await factory.getFunction('vetRouter')(newRouter.target);
         expect(await factory.getFunction('isAuthorizedRouter')(newRouter.target)).to.equal(false);
 
         // Enable — now authorized
@@ -317,8 +316,8 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
         );
         await expRouter.waitForDeployment();
 
-        // 1. Vet (off-chain admin)
-        await router.getFunction('vetRouter')(expRouter.target);
+        // 1. Vet (vetting authority)
+        await factory.getFunction('vetRouter')(expRouter.target);
 
         // 2. Enable (Agoric chain via GMP)
         (
@@ -339,14 +338,19 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
             })
         ).expectOperationSuccess();
 
-        // Experimental router can no longer operate
-        const lca2 = 'agoric1lifecycletest2345678901234abcdef';
-        const failReceipt = await expRoute(lca2).doRemoteAccountExecute({ multiCalls: [] });
+        // Experimental router can no longer operate (must include a call to trigger auth check)
+        const noopCall = {
+            target: factory.target as `0x${string}`,
+            data: '0x' as `0x${string}`,
+            value: 0n,
+            gasLimit: 0n,
+        };
+        const failReceipt = await expRoute(lca).doRemoteAccountExecute({ multiCalls: [noopCall] });
         const decodedError = failReceipt.parseOperationError(factory.interface);
         expect(decodedError?.name).to.equal('UnauthorizedCaller');
 
-        // 5. Revoke (off-chain admin)
-        await router.getFunction('revokeRouter')(expRouter.target);
+        // 5. Revoke (vetting authority)
+        await factory.getFunction('revokeRouter')(expRouter.target);
 
         // Cannot re-enable without vetting again
         const reEnableReceipt = await route(portfolioContractAccount).doEnableRouter({
@@ -354,23 +358,5 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
         });
         const reEnableError = reEnableReceipt.parseOperationError(factory.interface);
         expect(reEnableError?.name).to.equal('RouterNotVetted');
-    });
-
-    // ==================== renounceOwnership ====================
-
-    it('should reject renounceOwnership to prevent bricking all accounts', async () => {
-        // Impersonate the router (factory owner) to call renounceOwnership directly
-        const factoryOwner = await factory.owner();
-        await helpers.impersonateAccount(factoryOwner);
-        await helpers.setBalance(factoryOwner, ethers.parseEther('1'));
-        const routerSigner = await ethers.getSigner(factoryOwner);
-
-        await expect(factory.connect(routerSigner).getFunction('renounceOwnership')()).to.be
-            .reverted;
-
-        await helpers.stopImpersonatingAccount(factoryOwner);
-
-        // Verify ownership is unchanged
-        expect(await factory.owner()).to.equal(factoryOwner);
     });
 });

--- a/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountVetting.spec.ts
+++ b/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountVetting.spec.ts
@@ -373,4 +373,89 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
         const reEnableError = reEnableReceipt.parseOperationError(factory.interface);
         expect(reEnableError?.name).to.equal('RouterNotVetted');
     });
+
+    // ==================== Vetting Authority Transfer ====================
+    // NOTE: These tests are ordered carefully. The "propose" and "reject"
+    // tests run first (non-mutating or self-contained), then the successful
+    // confirm test transfers authority to addr1, and subsequent tests
+    // operate under that new authority.
+
+    it('should reject proposeVettingAuthorityTransfer from non-vetting-authority', async () => {
+        await expect(
+            factory.connect(addr1).getFunction('proposeVettingAuthorityTransfer')(addr1.address),
+        ).to.be.revertedWithCustomError(factory, 'UnauthorizedCaller');
+    });
+
+    it('should reject confirmVettingAuthorityTransfer when nothing was proposed', async () => {
+        const receipt = await route(portfolioContractAccount).doConfirmVettingAuthority({
+            authority: addr1.address as `0x${string}`,
+        });
+        const decodedError = receipt.parseOperationError(factory.interface);
+        expect(decodedError?.name).to.equal('InvalidVettingAuthority');
+    });
+
+    it('should propose vetting authority transfer and emit VettingAuthorityTransferProposed', async () => {
+        await expect(factory.getFunction('proposeVettingAuthorityTransfer')(addr1.address))
+            .to.emit(factory, 'VettingAuthorityTransferProposed')
+            .withArgs(owner.address, addr1.address);
+    });
+
+    it('should reject confirmVettingAuthorityTransfer with wrong address', async () => {
+        // Previous test proposed addr1; try to confirm with owner instead
+        const receipt = await route(portfolioContractAccount).doConfirmVettingAuthority({
+            authority: owner.address as `0x${string}`,
+        });
+        const decodedError = receipt.parseOperationError(factory.interface);
+        expect(decodedError?.name).to.equal('InvalidVettingAuthority');
+    });
+
+    it('should reject confirmVettingAuthorityTransfer from non-factory-principal', async () => {
+        // addr1 is still the pending authority from the propose test
+        const nonPrincipalLCA = 'agoric1notprincipal12345678901234abcde';
+        const receipt = await route(nonPrincipalLCA).doConfirmVettingAuthority({
+            authority: addr1.address as `0x${string}`,
+        });
+        const decodedError = receipt.parseOperationError(router.interface);
+        expect(decodedError?.name).to.equal('UnauthorizedCaller');
+    });
+
+    it('should confirm vetting authority transfer via GMP and emit VettingAuthorityTransferred', async () => {
+        // addr1 is still pending from the propose test above
+        const receipt = await route(portfolioContractAccount).doConfirmVettingAuthority({
+            authority: addr1.address as `0x${string}`,
+        });
+        receipt.expectOperationSuccess();
+
+        // Verify the vetting authority has changed
+        expect(await factory.getFunction('vettingAuthority')()).to.equal(addr1.address);
+    });
+
+    it('should allow new vetting authority to vet routers after transfer', async () => {
+        // Authority was transferred to addr1 by the previous test
+        const RouterContract = await ethers.getContractFactory('RemoteAccountAxelarRouter');
+        const newRouter = await RouterContract.deploy(
+            axelarGatewayMock.target,
+            sourceChain,
+            factory.target,
+            permit2Mock.target,
+        );
+        await newRouter.waitForDeployment();
+
+        await expect(factory.connect(addr1).getFunction('vetRouter')(newRouter.target))
+            .to.emit(factory, 'RouterVetted')
+            .withArgs(newRouter.target);
+
+        // Old vetting authority (owner) can no longer vet
+        const anotherRouter = await RouterContract.deploy(
+            axelarGatewayMock.target,
+            sourceChain,
+            factory.target,
+            permit2Mock.target,
+        );
+        await anotherRouter.waitForDeployment();
+
+        await expect(
+            factory.connect(owner).getFunction('vetRouter')(anotherRouter.target),
+        ).to.be.revertedWithCustomError(factory, 'UnauthorizedCaller');
+    });
 });

--- a/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountVetting.spec.ts
+++ b/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountVetting.spec.ts
@@ -5,7 +5,7 @@ import { ethers } from 'hardhat';
 import '@nomicfoundation/hardhat-chai-matchers';
 import { HardhatEthersSigner } from '@nomicfoundation/hardhat-ethers/signers';
 import * as helpers from '@nomicfoundation/hardhat-network-helpers';
-import { routed, deployRemoteAccountFactory } from './lib/utils';
+import { routed, deployRemoteAccountFactory, predictDeployAddress } from './lib/utils';
 
 describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
     let owner: HardhatEthersSigner, addr1: HardhatEthersSigner;
@@ -47,9 +47,13 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
         const MockPermit2Factory = await ethers.getContractFactory('MockPermit2');
         permit2Mock = await MockPermit2Factory.deploy();
 
+        // Predict the router address so the factory can enable it at construction
+        const predictedRouterAddress = await predictDeployAddress(owner, 2);
+
         factory = await deployRemoteAccountFactory(
             portfolioContractCaip2,
             portfolioContractAccount,
+            predictedRouterAddress,
         );
 
         const RouterContract = await ethers.getContractFactory('RemoteAccountAxelarRouter');
@@ -58,12 +62,8 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
             sourceChain,
             factory.target,
             permit2Mock.target,
-            owner.address,
         );
         await router.waitForDeployment();
-
-        await factory.getFunction('vetRouter')(router.target);
-        await factory.getFunction('transferOwnership')(router.target);
 
         routeConfig = {
             sourceChain,
@@ -84,7 +84,6 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
             sourceChain,
             factory.target,
             permit2Mock.target,
-            owner.address,
         );
         await newRouter.waitForDeployment();
 
@@ -93,7 +92,7 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
             .withArgs(newRouter.target);
 
         // Vetted but not yet enabled — not authorized
-        expect(await factory.getFunction('isAuthorizedCaller')(newRouter.target)).to.equal(false);
+        expect(await factory.getFunction('isAuthorizedRouter')(newRouter.target)).to.equal(false);
     });
 
     it('should reject vetRouter from non-owner', async () => {
@@ -111,13 +110,12 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
             sourceChain,
             factory.target,
             permit2Mock.target,
-            owner.address,
         );
         await newRouter.waitForDeployment();
 
         // Vet first
         await router.getFunction('vetRouter')(newRouter.target);
-        expect(await factory.getFunction('isAuthorizedCaller')(newRouter.target)).to.equal(false);
+        expect(await factory.getFunction('isAuthorizedRouter')(newRouter.target)).to.equal(false);
 
         // Enable via GMP from factory principal
         const receipt = await route(portfolioContractAccount).doEnableRouter({
@@ -126,7 +124,7 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
         receipt.expectOperationSuccess();
 
         // Now authorized
-        expect(await factory.getFunction('isAuthorizedCaller')(newRouter.target)).to.equal(true);
+        expect(await factory.getFunction('isAuthorizedRouter')(newRouter.target)).to.equal(true);
     });
 
     it('should reject enabling an un-vetted router', async () => {
@@ -146,7 +144,6 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
             sourceChain,
             factory.target,
             permit2Mock.target,
-            owner.address,
         );
         await newRouter.waitForDeployment();
         await router.getFunction('vetRouter')(newRouter.target);
@@ -170,7 +167,6 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
             sourceChain,
             factory.target,
             permit2Mock.target,
-            owner.address,
         );
         await newRouter.waitForDeployment();
 
@@ -181,7 +177,7 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
                 router: newRouter.target as `0x${string}`,
             })
         ).expectOperationSuccess();
-        expect(await factory.getFunction('isAuthorizedCaller')(newRouter.target)).to.equal(true);
+        expect(await factory.getFunction('isAuthorizedRouter')(newRouter.target)).to.equal(true);
 
         // Disable via GMP
         const receipt = await route(portfolioContractAccount).doDisableRouter({
@@ -190,7 +186,7 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
         receipt.expectOperationSuccess();
 
         // No longer authorized
-        expect(await factory.getFunction('isAuthorizedCaller')(newRouter.target)).to.equal(false);
+        expect(await factory.getFunction('isAuthorizedRouter')(newRouter.target)).to.equal(false);
     });
 
     it('should reject disableRouter from non-factory-principal', async () => {
@@ -213,7 +209,6 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
             sourceChain,
             factory.target,
             permit2Mock.target,
-            owner.address,
         );
         await newRouter.waitForDeployment();
 
@@ -243,7 +238,6 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
             sourceChain,
             factory.target,
             permit2Mock.target,
-            owner.address,
         );
         await newRouter.waitForDeployment();
 
@@ -267,14 +261,14 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
         ).to.be.revertedWithCustomError(router, 'OwnableUnauthorizedAccount');
     });
 
-    // ==================== isAuthorizedCaller ====================
+    // ==================== isAuthorizedRouter ====================
 
     it('should return true for factory owner', async () => {
-        expect(await factory.getFunction('isAuthorizedCaller')(router.target)).to.equal(true);
+        expect(await factory.getFunction('isAuthorizedRouter')(router.target)).to.equal(true);
     });
 
     it('should return false for random address', async () => {
-        expect(await factory.getFunction('isAuthorizedCaller')(addr1.address)).to.equal(false);
+        expect(await factory.getFunction('isAuthorizedRouter')(addr1.address)).to.equal(false);
     });
 
     it('should return true for enabled router and false after disabling', async () => {
@@ -284,16 +278,15 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
             sourceChain,
             factory.target,
             permit2Mock.target,
-            owner.address,
         );
         await newRouter.waitForDeployment();
 
         // Not authorized initially
-        expect(await factory.getFunction('isAuthorizedCaller')(newRouter.target)).to.equal(false);
+        expect(await factory.getFunction('isAuthorizedRouter')(newRouter.target)).to.equal(false);
 
         // Vet — still not authorized
         await router.getFunction('vetRouter')(newRouter.target);
-        expect(await factory.getFunction('isAuthorizedCaller')(newRouter.target)).to.equal(false);
+        expect(await factory.getFunction('isAuthorizedRouter')(newRouter.target)).to.equal(false);
 
         // Enable — now authorized
         (
@@ -301,7 +294,7 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
                 router: newRouter.target as `0x${string}`,
             })
         ).expectOperationSuccess();
-        expect(await factory.getFunction('isAuthorizedCaller')(newRouter.target)).to.equal(true);
+        expect(await factory.getFunction('isAuthorizedRouter')(newRouter.target)).to.equal(true);
 
         // Disable — no longer authorized
         (
@@ -309,7 +302,7 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
                 router: newRouter.target as `0x${string}`,
             })
         ).expectOperationSuccess();
-        expect(await factory.getFunction('isAuthorizedCaller')(newRouter.target)).to.equal(false);
+        expect(await factory.getFunction('isAuthorizedRouter')(newRouter.target)).to.equal(false);
     });
 
     // ==================== Full lifecycle ====================
@@ -321,7 +314,6 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
             sourceChain,
             factory.target,
             permit2Mock.target,
-            owner.address,
         );
         await expRouter.waitForDeployment();
 

--- a/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountVetting.spec.ts
+++ b/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountVetting.spec.ts
@@ -4,6 +4,7 @@ import { Contract } from 'ethers';
 import { ethers } from 'hardhat';
 import '@nomicfoundation/hardhat-chai-matchers';
 import { HardhatEthersSigner } from '@nomicfoundation/hardhat-ethers/signers';
+import * as helpers from '@nomicfoundation/hardhat-network-helpers';
 import { routed, deployRemoteAccountFactory } from './lib/utils';
 
 describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
@@ -361,5 +362,23 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
         });
         const reEnableError = reEnableReceipt.parseOperationError(factory.interface);
         expect(reEnableError?.name).to.equal('RouterNotVetted');
+    });
+
+    // ==================== renounceOwnership ====================
+
+    it('should reject renounceOwnership to prevent bricking all accounts', async () => {
+        // Impersonate the router (factory owner) to call renounceOwnership directly
+        const factoryOwner = await factory.owner();
+        await helpers.impersonateAccount(factoryOwner);
+        await helpers.setBalance(factoryOwner, ethers.parseEther('1'));
+        const routerSigner = await ethers.getSigner(factoryOwner);
+
+        await expect(factory.connect(routerSigner).getFunction('renounceOwnership')()).to.be
+            .reverted;
+
+        await helpers.stopImpersonatingAccount(factoryOwner);
+
+        // Verify ownership is unchanged
+        expect(await factory.owner()).to.equal(factoryOwner);
     });
 });

--- a/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountVetting.spec.ts
+++ b/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountVetting.spec.ts
@@ -4,7 +4,7 @@ import { Contract } from 'ethers';
 import { ethers } from 'hardhat';
 import '@nomicfoundation/hardhat-chai-matchers';
 import { HardhatEthersSigner } from '@nomicfoundation/hardhat-ethers/signers';
-import { routed, deployRemoteAccountFactory, predictDeployAddress } from './lib/utils';
+import { routed, deployRemoteAccountFactory } from './lib/utils';
 
 describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
     let owner: HardhatEthersSigner, addr1: HardhatEthersSigner;
@@ -46,13 +46,10 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
         const MockPermit2Factory = await ethers.getContractFactory('MockPermit2');
         permit2Mock = await MockPermit2Factory.deploy();
 
-        // Predict the router address so the factory can enable it at construction
-        const predictedRouterAddress = await predictDeployAddress(owner, 2);
-
         factory = await deployRemoteAccountFactory(
             portfolioContractCaip2,
             portfolioContractAccount,
-            predictedRouterAddress,
+            owner.address,
         );
 
         const RouterContract = await ethers.getContractFactory('RemoteAccountAxelarRouter');
@@ -63,6 +60,8 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
             permit2Mock.target,
         );
         await router.waitForDeployment();
+
+        await factory.getFunction('vetInitialRouter')(router.target);
 
         routeConfig = {
             sourceChain,
@@ -97,6 +96,21 @@ describe('RemoteAccountAxelarRouter - Vetting and Authorization', () => {
     it('should reject vetRouter from non-vetting-authority', async () => {
         await expect(
             factory.connect(addr1).getFunction('vetRouter')(addr1.address),
+        ).to.be.revertedWithCustomError(factory, 'UnauthorizedCaller');
+    });
+
+    it('should reject vetInitialRouter after a router is already authorized', async () => {
+        const RouterContract = await ethers.getContractFactory('RemoteAccountAxelarRouter');
+        const newRouter = await RouterContract.deploy(
+            axelarGatewayMock.target,
+            sourceChain,
+            factory.target,
+            permit2Mock.target,
+        );
+        await newRouter.waitForDeployment();
+
+        await expect(
+            factory.getFunction('vetInitialRouter')(newRouter.target),
         ).to.be.revertedWithCustomError(factory, 'UnauthorizedCaller');
     });
 

--- a/packages/axelar-local-dev-cosmos/src/__tests__/lib/utils.ts
+++ b/packages/axelar-local-dev-cosmos/src/__tests__/lib/utils.ts
@@ -16,11 +16,7 @@ import {
     RouterOperationPayload,
     SupportedOperations,
 } from '../../interfaces/router';
-import {
-    gmpRouterContract,
-    padTxId,
-    predictRemoteAccountAddress,
-} from '../../utils/router';
+import { gmpRouterContract, padTxId, predictRemoteAccountAddress } from '../../utils/router';
 
 // ==================== RemoteAccount Helpers ====================
 
@@ -35,7 +31,6 @@ export const deployRemoteAccountFactory = async (
     const RemoteAccountContract = await ethers.getContractFactory('RemoteAccount');
     const impl = await RemoteAccountContract.deploy();
     await impl.waitForDeployment();
-    await impl.renounceOwnership();
 
     const FactoryContract = await ethers.getContractFactory('RemoteAccountFactory');
     const factory = await FactoryContract.deploy(principalCaip2, principalAccount, impl.target);

--- a/packages/axelar-local-dev-cosmos/src/__tests__/lib/utils.ts
+++ b/packages/axelar-local-dev-cosmos/src/__tests__/lib/utils.ts
@@ -21,24 +21,12 @@ import { gmpRouterContract, padTxId, predictRemoteAccountAddress } from '../../u
 // ==================== RemoteAccount Helpers ====================
 
 /**
- * Predict the address of a contract deployed at a future nonce offset.
- */
-export const predictDeployAddress = async (
-    deployer: { address: string },
-    nonceOffset: number = 0,
-) => {
-    const nonce = await ethers.provider.getTransactionCount(deployer.address);
-    return ethers.getCreateAddress({ from: deployer.address, nonce: nonce + nonceOffset });
-};
-
-/**
  * Deploy the RemoteAccount implementation and RemoteAccountFactory.
  */
 export const deployRemoteAccountFactory = async (
     principalCaip2: string,
     principalAccount: string,
-    initialRouter: string,
-    vettingAuthority: string = ethers.ZeroAddress,
+    vettingAuthority: string,
 ) => {
     const RemoteAccountContract = await ethers.getContractFactory('RemoteAccount');
     const impl = await RemoteAccountContract.deploy();
@@ -49,7 +37,6 @@ export const deployRemoteAccountFactory = async (
         principalCaip2,
         principalAccount,
         impl.target,
-        initialRouter,
         vettingAuthority,
     );
     await factory.waitForDeployment();

--- a/packages/axelar-local-dev-cosmos/src/__tests__/lib/utils.ts
+++ b/packages/axelar-local-dev-cosmos/src/__tests__/lib/utils.ts
@@ -22,7 +22,6 @@ import { gmpRouterContract, padTxId, predictRemoteAccountAddress } from '../../u
 
 /**
  * Deploy the RemoteAccount implementation and RemoteAccountFactory.
- * The implementation's ownership is renounced to make it inert.
  */
 export const deployRemoteAccountFactory = async (
     principalCaip2: string,

--- a/packages/axelar-local-dev-cosmos/src/__tests__/lib/utils.ts
+++ b/packages/axelar-local-dev-cosmos/src/__tests__/lib/utils.ts
@@ -21,18 +21,37 @@ import { gmpRouterContract, padTxId, predictRemoteAccountAddress } from '../../u
 // ==================== RemoteAccount Helpers ====================
 
 /**
+ * Predict the address of a contract deployed at a future nonce offset.
+ */
+export const predictDeployAddress = async (
+    deployer: { address: string },
+    nonceOffset: number = 0,
+) => {
+    const nonce = await ethers.provider.getTransactionCount(deployer.address);
+    return ethers.getCreateAddress({ from: deployer.address, nonce: nonce + nonceOffset });
+};
+
+/**
  * Deploy the RemoteAccount implementation and RemoteAccountFactory.
  */
 export const deployRemoteAccountFactory = async (
     principalCaip2: string,
     principalAccount: string,
+    initialRouter: string,
+    vettingAuthority: string = ethers.ZeroAddress,
 ) => {
     const RemoteAccountContract = await ethers.getContractFactory('RemoteAccount');
     const impl = await RemoteAccountContract.deploy();
     await impl.waitForDeployment();
 
     const FactoryContract = await ethers.getContractFactory('RemoteAccountFactory');
-    const factory = await FactoryContract.deploy(principalCaip2, principalAccount, impl.target);
+    const factory = await FactoryContract.deploy(
+        principalCaip2,
+        principalAccount,
+        impl.target,
+        initialRouter,
+        vettingAuthority,
+    );
     await factory.waitForDeployment();
     return factory;
 };

--- a/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccount.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccount.sol
@@ -12,18 +12,14 @@ import { IRemoteAccountFactory } from './interfaces/IRemoteAccountFactory.sol';
  * @dev Caller authorization is resolved through the factory that deployed this
  *      clone: any router authorized by the factory can execute calls on this
  *      account.
- *      The principal account for which the factory deterministically deployed
- *      this RemoteAccount using CREATE2 is documented but not used on-chain.
+ *      This contract does not track its principal directly but instead relies
+ *      on RemoteAccountFactory to deploy it at a predictable CREATE2 address
+ *      derived from the principal.
  */
 contract RemoteAccount is Initializable, IRemoteAccount {
     /// @notice The factory that deployed this clone.
     /// @dev Set once during initialize.
     address public override factory;
-
-    /// @notice The principal account represented by this RemoteAccount.
-    /// @dev Set once during initialize. The CAIP-2 chain identifier can be
-    ///      looked up on the factory's `factoryPrincipalCaip2`.
-    string public override principalAccount;
 
     constructor() {
         _disableInitializers();
@@ -37,13 +33,11 @@ contract RemoteAccount is Initializable, IRemoteAccount {
      *      deploying this contract using proxies must call this function on
      *      each clone after deploying it.
      * @param factory_ The factory that deployed this clone
-     * @param principalAccount_ The principal account represented by this RemoteAccount
      */
-    function initialize(address factory_, string memory principalAccount_) external initializer {
+    function initialize(address factory_) external initializer {
         assert(factory == address(0));
         require(factory_ != address(0));
         factory = factory_;
-        principalAccount = principalAccount_;
     }
 
     /**

--- a/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccount.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccount.sol
@@ -10,8 +10,8 @@ import { IRemoteAccountFactory } from './interfaces/IRemoteAccountFactory.sol';
  * @notice A wallet contract representing a principal account, controlled
  *         through the factory's authorized callers (such as an IRemoteAccountRouter).
  * @dev Ownership is resolved transitively through the factory that deployed this
- *      clone: any caller authorized by the factory (its owner or an enabled
- *      router) can execute calls on this account.
+ *      clone: any router enabled by the factory can execute calls on this
+ *      account.
  *      This contract does not track its principal directly but instead relies
  *      on RemoteAccountFactory to deploy it at a predictable CREATE2 address
  *      derived from the principal.

--- a/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccount.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccount.sol
@@ -41,6 +41,7 @@ contract RemoteAccount is Initializable, IRemoteAccount {
      */
     function initialize(address factory_, string memory principalAccount_) external initializer {
         assert(factory == address(0));
+        require(factory_ != address(0));
         factory = factory_;
         principalAccount = principalAccount_;
     }

--- a/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccount.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccount.sol
@@ -54,9 +54,7 @@ contract RemoteAccount is Initializable, IRemoteAccount {
      * @param calls Array of contract calls to execute
      */
     function executeCalls(ContractCall[] calldata calls) external payable override {
-        if (!IRemoteAccountFactory(factory).isAuthorizedRouter(msg.sender)) {
-            revert UnauthorizedCaller(msg.sender);
-        }
+        IRemoteAccountFactory(factory).checkAuthorizedRouter(msg.sender);
         if (msg.value > 0) {
             emit Received(msg.sender, msg.value);
         }

--- a/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccount.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccount.sol
@@ -9,7 +9,7 @@ import { IRemoteAccountFactory } from './interfaces/IRemoteAccountFactory.sol';
  * @title RemoteAccount
  * @notice A wallet contract representing a principal account, controlled
  *         through the factory's authorized callers (such as an IRemoteAccountRouter).
- * @dev Ownership is resolved transitively through the factory that deployed this
+ * @dev Caller authorization is resolved through the factory that deployed this
  *      clone: any router enabled by the factory can execute calls on this
  *      account.
  *      This contract does not track its principal directly but instead relies
@@ -19,7 +19,7 @@ import { IRemoteAccountFactory } from './interfaces/IRemoteAccountFactory.sol';
 contract RemoteAccount is Initializable, IRemoteAccount {
     /// @notice The factory that deployed this clone.
     /// @dev Set once during initialize.
-    address public factory;
+    address public override factory;
 
     constructor() {
         _disableInitializers();

--- a/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccount.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccount.sol
@@ -12,14 +12,18 @@ import { IRemoteAccountFactory } from './interfaces/IRemoteAccountFactory.sol';
  * @dev Caller authorization is resolved through the factory that deployed this
  *      clone: any router enabled by the factory can execute calls on this
  *      account.
- *      This contract does not track its principal directly but instead relies
- *      on RemoteAccountFactory to deploy it at a predictable CREATE2 address
- *      derived from the principal.
+ *      The principal account for which the factory deterministically deployed
+ *      this RemoteAccount using CREATE2 is documented but not used on-chain.
  */
 contract RemoteAccount is Initializable, IRemoteAccount {
     /// @notice The factory that deployed this clone.
     /// @dev Set once during initialize.
     address public override factory;
+
+    /// @notice The principal account represented by this RemoteAccount.
+    /// @dev Set once during initialize. The CAIP-2 chain identifier can be
+    ///      looked up on the factory's `factoryPrincipalCaip2`.
+    string public override principalAccount;
 
     constructor() {
         _disableInitializers();
@@ -33,10 +37,12 @@ contract RemoteAccount is Initializable, IRemoteAccount {
      *      deploying this contract using proxies must call this function on
      *      each clone after deploying it.
      * @param factory_ The factory that deployed this clone
+     * @param principalAccount_ The principal account represented by this RemoteAccount
      */
-    function initialize(address factory_) external initializer {
+    function initialize(address factory_, string memory principalAccount_) external initializer {
         assert(factory == address(0));
         factory = factory_;
+        principalAccount = principalAccount_;
     }
 
     /**

--- a/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccount.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccount.sol
@@ -10,7 +10,7 @@ import { IRemoteAccountFactory } from './interfaces/IRemoteAccountFactory.sol';
  * @notice A wallet contract representing a principal account, controlled
  *         through the factory's authorized callers (such as an IRemoteAccountRouter).
  * @dev Caller authorization is resolved through the factory that deployed this
- *      clone: any router enabled by the factory can execute calls on this
+ *      clone: any router authorized by the factory can execute calls on this
  *      account.
  *      The principal account for which the factory deterministically deployed
  *      this RemoteAccount using CREATE2 is documented but not used on-chain.

--- a/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccount.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccount.sol
@@ -2,49 +2,58 @@
 pragma solidity ^0.8.20;
 
 import { Initializable } from '@openzeppelin/contracts/proxy/utils/Initializable.sol';
-import { Ownable } from '@openzeppelin/contracts/access/Ownable.sol';
 import { IRemoteAccount, ContractCall } from './interfaces/IRemoteAccount.sol';
+import { IRemoteAccountFactory } from './interfaces/IRemoteAccountFactory.sol';
 
 /**
  * @title RemoteAccount
  * @notice A wallet contract representing a principal account, controlled
- *         through a replaceable owner (such as an IRemoteAccountRouter).
- * @dev An Ownable for address-based, transferable ownership.
+ *         through the factory's authorized callers (such as an IRemoteAccountRouter).
+ * @dev Ownership is resolved transitively through the factory that deployed this
+ *      clone: any caller authorized by the factory (its owner or an enabled
+ *      router) can execute calls on this account.
  *      This contract does not track its principal directly but instead relies
  *      on RemoteAccountFactory to deploy it at a predictable CREATE2 address
- *      derived from the principal. The owner is responsible for validating the
- *      remote account's address against the acting principal on each call.
- *      This design keeps RemoteAccount as simple as possible while still
- *      supporting migration paths in which the original owner is replaced with
- *      a new contract.
+ *      derived from the principal.
  */
-contract RemoteAccount is Ownable, Initializable, IRemoteAccount {
-    constructor() Ownable(_msgSender()) {
+contract RemoteAccount is Initializable, IRemoteAccount {
+    /// @dev The factory that deployed this clone. Set once during initialize.
+    address private _factory;
+
+    constructor() {
         _disableInitializers();
     }
 
     /**
-     * @notice Initialize ownership for an EIP-1167 clone
-     * @dev Clones do not run constructors, so _owner starts as address(0).
+     * @notice Initialize the factory reference for an EIP-1167 clone
+     * @dev Clones do not run constructors, so _factory starts as address(0).
      *      We use the initializer modifier to ensure this function can only be
      *      called once by contracts that weren't constructed. A factory
      *      deploying this contract using proxies must call this function on
-     *      each clone after deploying it, to set the initial owner.
-     * @param initialOwner The address to set as the owner of this clone
+     *      each clone after deploying it.
+     * @param factory_ The factory that deployed this clone
      */
-    function initialize(address initialOwner) external initializer {
-        assert(owner() == address(0));
-        _transferOwnership(initialOwner);
+    function initialize(address factory_) external initializer {
+        assert(_factory == address(0));
+        _factory = factory_;
+    }
+
+    /// @notice The factory that deployed this clone
+    function factory() external view override returns (address) {
+        return _factory;
     }
 
     /**
      * @notice Execute a batch of calls on behalf of the principal
-     * @dev The owner is the only authorized caller, and is expected to
-     *      target this RemoteAccount after using the RemoteAccountFactory that
-     *      created it to re-derive its address from the acting principal.
+     * @dev Only callers authorized by the factory can execute calls.
+     *      The caller is expected to use the RemoteAccountFactory to
+     *      re-derive this account's address from the acting principal.
      * @param calls Array of contract calls to execute
      */
-    function executeCalls(ContractCall[] calldata calls) external payable override onlyOwner {
+    function executeCalls(ContractCall[] calldata calls) external payable override {
+        if (!IRemoteAccountFactory(_factory).isAuthorizedCaller(msg.sender)) {
+            revert UnauthorizedCaller(msg.sender);
+        }
         if (msg.value > 0) {
             emit Received(msg.sender, msg.value);
         }

--- a/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccount.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccount.sol
@@ -17,8 +17,9 @@ import { IRemoteAccountFactory } from './interfaces/IRemoteAccountFactory.sol';
  *      derived from the principal.
  */
 contract RemoteAccount is Initializable, IRemoteAccount {
-    /// @dev The factory that deployed this clone. Set once during initialize.
-    address private _factory;
+    /// @notice The factory that deployed this clone.
+    /// @dev Set once during initialize.
+    address public factory;
 
     constructor() {
         _disableInitializers();
@@ -26,7 +27,7 @@ contract RemoteAccount is Initializable, IRemoteAccount {
 
     /**
      * @notice Initialize the factory reference for an EIP-1167 clone
-     * @dev Clones do not run constructors, so _factory starts as address(0).
+     * @dev Clones do not run constructors, so factory starts as address(0).
      *      We use the initializer modifier to ensure this function can only be
      *      called once by contracts that weren't constructed. A factory
      *      deploying this contract using proxies must call this function on
@@ -34,24 +35,19 @@ contract RemoteAccount is Initializable, IRemoteAccount {
      * @param factory_ The factory that deployed this clone
      */
     function initialize(address factory_) external initializer {
-        assert(_factory == address(0));
-        _factory = factory_;
-    }
-
-    /// @notice The factory that deployed this clone
-    function factory() external view override returns (address) {
-        return _factory;
+        assert(factory == address(0));
+        factory = factory_;
     }
 
     /**
      * @notice Execute a batch of calls on behalf of the principal
-     * @dev Only callers authorized by the factory can execute calls.
+     * @dev Only routers authorized by the factory can execute calls.
      *      The caller is expected to use the RemoteAccountFactory to
      *      re-derive this account's address from the acting principal.
      * @param calls Array of contract calls to execute
      */
     function executeCalls(ContractCall[] calldata calls) external payable override {
-        if (!IRemoteAccountFactory(_factory).isAuthorizedCaller(msg.sender)) {
+        if (!IRemoteAccountFactory(factory).isAuthorizedRouter(msg.sender)) {
             revert UnauthorizedCaller(msg.sender);
         }
         if (msg.value > 0) {

--- a/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountAxelarRouter.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountAxelarRouter.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.20;
 import { AxelarExecutable } from '@updated-axelar-network/axelar-gmp-sdk-solidity/contracts/executable/AxelarExecutable.sol';
 import { IRemoteAccountFactory } from './interfaces/IRemoteAccountFactory.sol';
 import { IRemoteAccount, ContractCall } from './interfaces/IRemoteAccount.sol';
-import { IRemoteAccountRouter, IPermit2, DepositPermit, ProvideRemoteAccountInstruction, RemoteAccountExecuteInstruction, EnableRouterInstruction, DisableRouterInstruction, ConfirmVettingAuthorityInstruction } from './interfaces/IRemoteAccountRouter.sol';
+import { IRemoteAccountRouter, IPermit2, DepositPermit, ProvideRemoteAccountInstruction, RemoteAccountExecuteInstruction, AuthorizeRouterInstruction, DeauthorizeRouterInstruction, ConfirmVettingAuthorityInstruction } from './interfaces/IRemoteAccountRouter.sol';
 
 /**
  * @title RemoteAccountAxelarRouter
@@ -12,19 +12,19 @@ import { IRemoteAccountRouter, IPermit2, DepositPermit, ProvideRemoteAccountInst
  * @dev Handles account creation, deposits, and multicalls atomically.
  *      Remote accounts delegate authorization to the factory that deployed them:
  *      any caller authorized by the factory can operate any accounts it created.
- *      This enables O(1) router migration — updating router status in the
+ *      This supports O(1) router migration — updating router status in the
  *      factory instantly updates the caller authorization for all accounts.
  *
- *      The factory maintains a vetted/enabled router map for two-factor
+ *      The factory maintains a vetted/authorized router map for two-factor
  *      authorization:
- *      - Vetting: the factory's vetting authority can vet or revoke routers
+ *      - Vetting: the factory's vetting authority can vet or unvet routers
  *        via direct calls
- *      - Enabling (operational switch): the Agoric chain principal can
- *        enable or disable vetted routers via GMP messages
+ *      - Authorization (operational switch): the Agoric chain principal can
+ *        authorize or deauthorize vetted routers via GMP messages
  *
  *      Migration to a new router is done in 2 steps:
- *      1. the vetting authority vets and the principal enables the new router
- *      2. the principal optionally disables the old router via GMP
+ *      1. the vetting authority vets and the principal authorizes the new router
+ *      2. the principal optionally deauthorizes the old router via GMP
  */
 contract RemoteAccountAxelarRouter is AxelarExecutable, IRemoteAccountRouter {
     IRemoteAccountFactory public immutable override factory;
@@ -129,8 +129,8 @@ contract RemoteAccountAxelarRouter is AxelarExecutable, IRemoteAccountRouter {
         if (
             selector != RemoteAccountAxelarRouter.processRemoteAccountExecuteInstruction.selector &&
             selector != RemoteAccountAxelarRouter.processProvideRemoteAccountInstruction.selector &&
-            selector != RemoteAccountAxelarRouter.processEnableRouterInstruction.selector &&
-            selector != RemoteAccountAxelarRouter.processDisableRouterInstruction.selector &&
+            selector != RemoteAccountAxelarRouter.processAuthorizeRouterInstruction.selector &&
+            selector != RemoteAccountAxelarRouter.processDeauthorizeRouterInstruction.selector &&
             selector != RemoteAccountAxelarRouter.processConfirmVettingAuthorityInstruction.selector
         ) {
             revert InvalidInstructionSelector(selector);
@@ -232,7 +232,7 @@ contract RemoteAccountAxelarRouter is AxelarExecutable, IRemoteAccountRouter {
         // resolver to observe/trace transactions.
         // Note that the second argument of all functions is an address: either the
         // expected remote account address or the factory address (for admin
-        // operations like EnableRouter, DisableRouter, ConfirmVettingAuthority).
+        // operations like AuthorizeRouter, DeauthorizeRouter, ConfirmVettingAuthority).
         // It is included in the emitted OperationResult event.
 
         bytes4 selector = bytes4(payload[:4]);
@@ -372,18 +372,18 @@ contract RemoteAccountAxelarRouter is AxelarExecutable, IRemoteAccountRouter {
     }
 
     /**
-     * @notice Process an enable router instruction
+     * @notice Process an authorize router instruction
      * @dev This is an external function which can only be called by this contract.
-     *      Only the factory's principal can enable routers via GMP.
+     *      Only the factory's principal can authorize routers via GMP.
      *      The router must be vetted first.
      * @param sourceAddress The principal account address of the factory
      * @param factoryAddress The expected factory address
-     * @param instruction The decoded EnableRouterInstruction
+     * @param instruction The decoded AuthorizeRouterInstruction
      */
-    function processEnableRouterInstruction(
+    function processAuthorizeRouterInstruction(
         string calldata sourceAddress,
         address factoryAddress,
-        EnableRouterInstruction calldata instruction
+        AuthorizeRouterInstruction calldata instruction
     ) external override {
         require(msg.sender == address(this));
 
@@ -392,22 +392,22 @@ contract RemoteAccountAxelarRouter is AxelarExecutable, IRemoteAccountRouter {
         }
         factory.verifyFactoryPrincipalAccount(sourceAddress);
 
-        factory.enableRouter(instruction.router);
+        factory.authorizeRouter(instruction.router);
     }
 
     /**
-     * @notice Process a disable router instruction
+     * @notice Process a deauthorize router instruction
      * @dev This is an external function which can only be called by this contract.
-     *      Only the factory's principal can disable routers via GMP.
-     *      The current router cannot disable itself.
+     *      Only the factory's principal can deauthorize routers via GMP.
+     *      The current router cannot deauthorize itself.
      * @param sourceAddress The principal account address of the factory
      * @param factoryAddress The expected factory address
-     * @param instruction The decoded DisableRouterInstruction
+     * @param instruction The decoded DeauthorizeRouterInstruction
      */
-    function processDisableRouterInstruction(
+    function processDeauthorizeRouterInstruction(
         string calldata sourceAddress,
         address factoryAddress,
-        DisableRouterInstruction calldata instruction
+        DeauthorizeRouterInstruction calldata instruction
     ) external override {
         require(msg.sender == address(this));
 
@@ -416,6 +416,6 @@ contract RemoteAccountAxelarRouter is AxelarExecutable, IRemoteAccountRouter {
         }
         factory.verifyFactoryPrincipalAccount(sourceAddress);
 
-        factory.disableRouter(instruction.router);
+        factory.deauthorizeRouter(instruction.router);
     }
 }

--- a/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountAxelarRouter.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountAxelarRouter.sol
@@ -239,9 +239,10 @@ contract RemoteAccountAxelarRouter is AxelarExecutable, ImmutableOwnable, IRemot
         // to match the length of the address and minimize gas costs.
         // The transaction id is included in the OperationResult event, allowing a
         // resolver to observe/trace transactions.
-        // Note that the second argument of all functions is `expectedAddress`,
-        // relevant to RemoteAccountFactory and also included in the emitted
-        // OperationResult event.
+        // Note that the second argument of all functions is an address: either the
+        // expected remote account address or the factory address (for admin
+        // operations like EnableRouter, DisableRouter, UpdateOwner).
+        // It is included in the emitted OperationResult event.
 
         bytes4 selector = bytes4(payload[:4]);
         bytes calldata encodedArgs = payload[4:];

--- a/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountAxelarRouter.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountAxelarRouter.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.20;
 
 import { AxelarExecutable } from '@updated-axelar-network/axelar-gmp-sdk-solidity/contracts/executable/AxelarExecutable.sol';
-import { Ownable } from '@openzeppelin/contracts/access/Ownable.sol';
 import { IRemoteAccountFactory } from './interfaces/IRemoteAccountFactory.sol';
 import { IRemoteAccount, ContractCall } from './interfaces/IRemoteAccount.sol';
 import { IRemoteAccountRouter, IPermit2, DepositPermit, ProvideRemoteAccountInstruction, RemoteAccountExecuteInstruction, EnableRouterInstruction, DisableRouterInstruction, ConfirmVettingAuthorityInstruction } from './interfaces/IRemoteAccountRouter.sol';
@@ -18,19 +17,14 @@ import { IRemoteAccountRouter, IPermit2, DepositPermit, ProvideRemoteAccountInst
  *
  *      The factory maintains a vetted/enabled router map with two-factor
  *      authorization:
- *      - Vetting: the ImmutableOwnable owner can vet
+ *      - Vetting: the factory's vetting authority can vet
  *        or revoke routers via direct calls
  *      - Enabling (operational switch): the Agoric chain principal can
  *        enable or disable vetted routers via GMP messages
  *
  *      Migration to a new router is done in 2 steps:
- *      1. the owner of this router vets and the principal enables the new router
- *      2. the principal account of the factory sends this router an UpdateOwner
- *         instruction to transfer factory ownership to the new (vetted) router
- *
- *      We use an immutable owner for the router, changing owner requires deploying
- *      a new router. This way a leak of owner credentials does not grant exclusive
- *      access to the router's management mechanism.
+ *      1. the vetting authority vets and the principal enables the new router
+ *      2. the principal optionally disables the old router via GMP
  */
 contract RemoteAccountAxelarRouter is AxelarExecutable, IRemoteAccountRouter {
     IRemoteAccountFactory public immutable override factory;

--- a/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountAxelarRouter.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountAxelarRouter.sol
@@ -10,15 +10,15 @@ import { IRemoteAccountRouter, IPermit2, DepositPermit, ProvideRemoteAccountInst
  * @title RemoteAccountAxelarRouter
  * @notice The single AxelarExecutable entry point for all remote account operations
  * @dev Handles account creation, deposits, and multicalls atomically.
- *      Remote accounts delegate ownership transitively through the factory:
- *      any caller authorized by the factory can operate any account.
- *      This enables O(1) router migration — transferring factory ownership
- *      instantly updates the authorized caller for all accounts.
+ *      Remote accounts delegate authorization to the factory that deployed them:
+ *      any caller authorized by the factory can operate any accounts it created.
+ *      This enables O(1) router migration — updating router status in the
+ *      factory instantly updates the caller authorization for all accounts.
  *
- *      The factory maintains a vetted/enabled router map with two-factor
+ *      The factory maintains a vetted/enabled router map for two-factor
  *      authorization:
- *      - Vetting: the factory's vetting authority can vet
- *        or revoke routers via direct calls
+ *      - Vetting: the factory's vetting authority can vet or revoke routers
+ *        via direct calls
  *      - Enabling (operational switch): the Agoric chain principal can
  *        enable or disable vetted routers via GMP messages
  *
@@ -353,11 +353,12 @@ contract RemoteAccountAxelarRouter is AxelarExecutable, IRemoteAccountRouter {
     }
 
     /**
-     * @notice Process the update owner instruction to transfer factory ownership
+     * @notice Process the instruction to confirm transfer of the factory vetting authority
      * @dev This is an external function which can only be called by this contract
      *      Used to create a call stack that can be reverted atomically
-     *      Only the factory's principal can trigger factory ownership transfer.
-     *      The new owner must be vetted by the factory.
+     *      Only the factory's principal can confirm the factory's vetting
+     *      authority transfer via GMP. The new vetting authority must be have
+     *      been previously proposed directly by the current vetting authority.
      * @param sourceAddress The principal account address of the factory
      * @param factoryAddress The expected factory address
      * @param instruction The decoded ConfirmVettingAuthorityInstruction
@@ -406,6 +407,7 @@ contract RemoteAccountAxelarRouter is AxelarExecutable, IRemoteAccountRouter {
      * @notice Process a disable router instruction
      * @dev This is an external function which can only be called by this contract.
      *      Only the factory's principal can disable routers via GMP.
+     *      The current router cannot disable itself.
      * @param sourceAddress The principal account address of the factory
      * @param factoryAddress The expected factory address
      * @param instruction The decoded DisableRouterInstruction

--- a/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountAxelarRouter.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountAxelarRouter.sol
@@ -250,15 +250,7 @@ contract RemoteAccountAxelarRouter is AxelarExecutable, IRemoteAccountRouter {
         (bool success, bytes memory result) = processInstruction(payload, sourceAddress);
 
         // Note that this is a transport-level event applicable to any instruction.
-        emit OperationResult(
-            txId,
-            sourceAddress,
-            sourceAddress,
-            expectedAddress,
-            selector,
-            success,
-            result
-        );
+        emit OperationResult(txId, sourceAddress, txId, expectedAddress, selector, success, result);
     }
 
     /**

--- a/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountAxelarRouter.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountAxelarRouter.sol
@@ -33,7 +33,7 @@ contract RemoteAccountAxelarRouter is AxelarExecutable, IRemoteAccountRouter {
     // Immutable, but cannot be declaratively marked as such because this is a string
     // Only used for validation error messages. The router is seldom deployed
     // so the cost of storing this string is accepted.
-    string private axelarSourceChain;
+    string public axelarSourceChain;
     bytes32 private immutable axelarSourceChainHash;
 
     error InvalidSourceChain(string expected, string actual);

--- a/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountAxelarRouter.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountAxelarRouter.sol
@@ -5,8 +5,7 @@ import { AxelarExecutable } from '@updated-axelar-network/axelar-gmp-sdk-solidit
 import { Ownable } from '@openzeppelin/contracts/access/Ownable.sol';
 import { IRemoteAccountFactory } from './interfaces/IRemoteAccountFactory.sol';
 import { IRemoteAccount, ContractCall } from './interfaces/IRemoteAccount.sol';
-import { ImmutableOwnable } from './ImmutableOwnable.sol';
-import { IRemoteAccountRouter, IPermit2, DepositPermit, ProvideRemoteAccountInstruction, RemoteAccountExecuteInstruction, UpdateOwnerInstruction, EnableRouterInstruction, DisableRouterInstruction } from './interfaces/IRemoteAccountRouter.sol';
+import { IRemoteAccountRouter, IPermit2, DepositPermit, ProvideRemoteAccountInstruction, RemoteAccountExecuteInstruction, EnableRouterInstruction, DisableRouterInstruction, ConfirmVettingAuthorityInstruction } from './interfaces/IRemoteAccountRouter.sol';
 
 /**
  * @title RemoteAccountAxelarRouter
@@ -33,7 +32,7 @@ import { IRemoteAccountRouter, IPermit2, DepositPermit, ProvideRemoteAccountInst
  *      a new router. This way a leak of owner credentials does not grant exclusive
  *      access to the router's management mechanism.
  */
-contract RemoteAccountAxelarRouter is AxelarExecutable, ImmutableOwnable, IRemoteAccountRouter {
+contract RemoteAccountAxelarRouter is AxelarExecutable, IRemoteAccountRouter {
     IRemoteAccountFactory public immutable override factory;
     IPermit2 public immutable override permit2;
 
@@ -53,15 +52,13 @@ contract RemoteAccountAxelarRouter is AxelarExecutable, ImmutableOwnable, IRemot
      * @param axelarSourceChain_ The source chain name
      * @param factory_ The RemoteAccountFactory address
      * @param permit2_ The Permit2 contract address
-     * @param owner The address authorized to vet and revoke routers
      */
     constructor(
         address axelarGateway,
         string memory axelarSourceChain_,
         address factory_,
-        address permit2_,
-        address owner
-    ) AxelarExecutable(axelarGateway) ImmutableOwnable(owner) {
+        address permit2_
+    ) AxelarExecutable(axelarGateway) {
         factory = IRemoteAccountFactory(factory_);
         permit2 = IPermit2(permit2_);
 
@@ -138,9 +135,9 @@ contract RemoteAccountAxelarRouter is AxelarExecutable, ImmutableOwnable, IRemot
         if (
             selector != RemoteAccountAxelarRouter.processRemoteAccountExecuteInstruction.selector &&
             selector != RemoteAccountAxelarRouter.processProvideRemoteAccountInstruction.selector &&
-            selector != RemoteAccountAxelarRouter.processUpdateOwnerInstruction.selector &&
             selector != RemoteAccountAxelarRouter.processEnableRouterInstruction.selector &&
-            selector != RemoteAccountAxelarRouter.processDisableRouterInstruction.selector
+            selector != RemoteAccountAxelarRouter.processDisableRouterInstruction.selector &&
+            selector != RemoteAccountAxelarRouter.processConfirmVettingAuthorityInstruction.selector
         ) {
             revert InvalidInstructionSelector(selector);
         }
@@ -241,7 +238,7 @@ contract RemoteAccountAxelarRouter is AxelarExecutable, ImmutableOwnable, IRemot
         // resolver to observe/trace transactions.
         // Note that the second argument of all functions is an address: either the
         // expected remote account address or the factory address (for admin
-        // operations like EnableRouter, DisableRouter, UpdateOwner).
+        // operations like EnableRouter, DisableRouter, ConfirmVettingAuthority).
         // It is included in the emitted OperationResult event.
 
         bytes4 selector = bytes4(payload[:4]);
@@ -369,21 +366,22 @@ contract RemoteAccountAxelarRouter is AxelarExecutable, ImmutableOwnable, IRemot
      *      The new owner must be vetted by the factory.
      * @param sourceAddress The principal account address of the factory
      * @param factoryAddress The expected factory address
-     * @param instruction The decoded UpdateOwnerInstruction
+     * @param instruction The decoded ConfirmVettingAuthorityInstruction
      */
-    function processUpdateOwnerInstruction(
+    function processConfirmVettingAuthorityInstruction(
         string calldata sourceAddress,
         address factoryAddress,
-        UpdateOwnerInstruction calldata instruction
+        ConfirmVettingAuthorityInstruction calldata instruction
     ) external override {
         require(msg.sender == address(this));
 
+        // Check the factory's principal is the source
         if (factoryAddress != address(factory)) {
             revert UnauthorizedCaller(sourceAddress);
         }
-
         factory.verifyFactoryPrincipalAccount(sourceAddress);
-        Ownable(address(factory)).transferOwnership(instruction.newOwner);
+
+        factory.confirmVettingAuthorityTransfer(instruction.authority);
     }
 
     /**
@@ -431,28 +429,5 @@ contract RemoteAccountAxelarRouter is AxelarExecutable, ImmutableOwnable, IRemot
         factory.verifyFactoryPrincipalAccount(sourceAddress);
 
         factory.disableRouter(instruction.router);
-    }
-
-    /**
-     * @notice Vet a router address
-     * @dev Can only be called by the immutable owner.
-     *      This marks a router as vetted in the factory but does not enable it.
-     *      Enabling must be done separately via a GMP message from the Agoric chain.
-     * @param router The address of the router to vet
-     */
-    function vetRouter(address router) external onlyOwner {
-        factory.vetRouter(router);
-        emit RouterVetted(router);
-    }
-
-    /**
-     * @notice Revoke vetting from a router
-     * @dev Can only be called by the immutable owner.
-     *      The router must be disabled first.
-     * @param router The address of the router to revoke
-     */
-    function revokeRouter(address router) external onlyOwner {
-        factory.revokeRouter(router);
-        emit RouterRevoked(router);
     }
 }

--- a/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountAxelarRouter.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountAxelarRouter.sol
@@ -357,8 +357,8 @@ contract RemoteAccountAxelarRouter is AxelarExecutable, IRemoteAccountRouter {
      * @dev This is an external function which can only be called by this contract
      *      Used to create a call stack that can be reverted atomically
      *      Only the factory's principal can confirm the factory's vetting
-     *      authority transfer via GMP. The new vetting authority must be have
-     *      been previously proposed directly by the current vetting authority.
+     *      authority transfer via GMP. The new vetting authority must have been
+     *      previously proposed directly by the current vetting authority.
      * @param sourceAddress The principal account address of the factory
      * @param factoryAddress The expected factory address
      * @param instruction The decoded ConfirmVettingAuthorityInstruction

--- a/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountAxelarRouter.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountAxelarRouter.sol
@@ -6,27 +6,32 @@ import { Ownable } from '@openzeppelin/contracts/access/Ownable.sol';
 import { IRemoteAccountFactory } from './interfaces/IRemoteAccountFactory.sol';
 import { IRemoteAccount, ContractCall } from './interfaces/IRemoteAccount.sol';
 import { ImmutableOwnable } from './ImmutableOwnable.sol';
-import { IRemoteAccountRouter, IPermit2, DepositPermit, ProvideRemoteAccountInstruction, RemoteAccountExecuteInstruction, UpdateOwnerInstruction } from './interfaces/IRemoteAccountRouter.sol';
+import { IRemoteAccountRouter, IPermit2, DepositPermit, ProvideRemoteAccountInstruction, RemoteAccountExecuteInstruction, UpdateOwnerInstruction, EnableRouterInstruction, DisableRouterInstruction } from './interfaces/IRemoteAccountRouter.sol';
 
 /**
  * @title RemoteAccountAxelarRouter
  * @notice The single AxelarExecutable entry point for all remote account operations
  * @dev Handles account creation, deposits, and multicalls atomically.
- *      Each RemoteAccount and the factory is owned by this router, enabling future migration
- *      by deploying a new router and transferring ownership.
+ *      Remote accounts delegate ownership transitively through the factory:
+ *      any caller authorized by the factory can operate any account.
+ *      This enables O(1) router migration — transferring factory ownership
+ *      instantly updates the authorized caller for all accounts.
  *
- *      Migration to a new router is done in 3 steps:
- *      1. the owner of this router calls `setSuccessor`
- *      2. the principal account of the associated RemoteAccountFactory sends
- *         this router an UpdateOwner instruction specifying as new owner the
- *         successor designated in step 1
- *      3. the principal account of each RemoteAccount owned by this router
- *         sends this router an UpdateOwner instruction like the one from step 2
+ *      The factory maintains a vetted/enabled router map with two-factor
+ *      authorization:
+ *      - Vetting: the ImmutableOwnable owner can vet
+ *        or revoke routers via direct calls
+ *      - Enabling (operational switch): the Agoric chain principal can
+ *        enable or disable vetted routers via GMP messages
  *
- *      We use an immutable owner for the router, changing owner requires designating a
- *      successor router with a different owner. This way a leak of owner credentials
- *      does not grant exclusive access to the router's successor mechanism, maintaining
- *      the possibility to transition owned contracts to a rightful successor.
+ *      Migration to a new router is done in 2 steps:
+ *      1. the owner of this router vets and the principal enables the new router
+ *      2. the principal account of the factory sends this router an UpdateOwner
+ *         instruction to transfer factory ownership to the new (vetted) router
+ *
+ *      We use an immutable owner for the router, changing owner requires deploying
+ *      a new router. This way a leak of owner credentials does not grant exclusive
+ *      access to the router's management mechanism.
  */
 contract RemoteAccountAxelarRouter is AxelarExecutable, ImmutableOwnable, IRemoteAccountRouter {
     IRemoteAccountFactory public immutable override factory;
@@ -38,8 +43,6 @@ contract RemoteAccountAxelarRouter is AxelarExecutable, ImmutableOwnable, IRemot
     string private axelarSourceChain;
     bytes32 private immutable axelarSourceChainHash;
 
-    address public successor;
-
     error InvalidSourceChain(string expected, string actual);
     error InvalidPayload(bytes4 selector);
 
@@ -50,7 +53,7 @@ contract RemoteAccountAxelarRouter is AxelarExecutable, ImmutableOwnable, IRemot
      * @param axelarSourceChain_ The source chain name
      * @param factory_ The RemoteAccountFactory address
      * @param permit2_ The Permit2 contract address
-     * @param owner The address authorized to designate a successor
+     * @param owner The address authorized to vet and revoke routers
      */
     constructor(
         address axelarGateway,
@@ -135,7 +138,9 @@ contract RemoteAccountAxelarRouter is AxelarExecutable, ImmutableOwnable, IRemot
         if (
             selector != RemoteAccountAxelarRouter.processRemoteAccountExecuteInstruction.selector &&
             selector != RemoteAccountAxelarRouter.processProvideRemoteAccountInstruction.selector &&
-            selector != RemoteAccountAxelarRouter.processUpdateOwnerInstruction.selector
+            selector != RemoteAccountAxelarRouter.processUpdateOwnerInstruction.selector &&
+            selector != RemoteAccountAxelarRouter.processEnableRouterInstruction.selector &&
+            selector != RemoteAccountAxelarRouter.processDisableRouterInstruction.selector
         ) {
             revert InvalidInstructionSelector(selector);
         }
@@ -328,7 +333,6 @@ contract RemoteAccountAxelarRouter is AxelarExecutable, ImmutableOwnable, IRemot
 
         factory.provideRemoteAccount(
             instruction.principalAccount,
-            address(this),
             instruction.expectedAccountAddress
         );
     }
@@ -348,8 +352,8 @@ contract RemoteAccountAxelarRouter is AxelarExecutable, ImmutableOwnable, IRemot
     ) external override {
         require(msg.sender == address(this));
 
-        // Provide or verify the remote account matches the source principal and its owner is this router
-        factory.provideRemoteAccount(sourceAddress, address(this), expectedAccountAddress);
+        // Provide or verify the remote account exists at the expected address
+        factory.provideRemoteAccount(sourceAddress, expectedAccountAddress);
 
         if (instruction.multiCalls.length > 0) {
             IRemoteAccount(expectedAccountAddress).executeCalls(instruction.multiCalls);
@@ -357,55 +361,97 @@ contract RemoteAccountAxelarRouter is AxelarExecutable, ImmutableOwnable, IRemot
     }
 
     /**
-     * @notice Process the update owner instruction
+     * @notice Process the update owner instruction to transfer factory ownership
      * @dev This is an external function which can only be called by this contract
      *      Used to create a call stack that can be reverted atomically
-     *      The owned contract can be a RemoteAccount or the factory
-     * @param sourceAddress The principal account address of the owned contract
-     * @param expectedAccountAddress The expected contract address corresponding to the principal address
+     *      Only the factory's principal can trigger factory ownership transfer.
+     *      The new owner must be vetted by the factory.
+     * @param sourceAddress The principal account address of the factory
+     * @param factoryAddress The expected factory address
      * @param instruction The decoded UpdateOwnerInstruction
      */
     function processUpdateOwnerInstruction(
         string calldata sourceAddress,
-        address expectedAccountAddress,
+        address factoryAddress,
         UpdateOwnerInstruction calldata instruction
     ) external override {
         require(msg.sender == address(this));
 
-        address newOwner = instruction.newOwner;
-
-        if (newOwner == address(0) || newOwner != successor) {
-            revert Ownable.OwnableInvalidOwner(newOwner);
+        if (factoryAddress != address(factory)) {
+            revert UnauthorizedCaller(sourceAddress);
         }
 
-        if (expectedAccountAddress == address(factory)) {
-            // Before transferring the factory, verify that this call comes from
-            // its principal account
-            // No need to check the factory's current owner as the transfer will
-            // fail if that's not us
-            factory.verifyFactoryPrincipalAccount(sourceAddress);
-        } else {
-            // Provide or verify the remote account matches the source principal and owner
-            // The factory does an owner check as part of this, even though transfer would also check it.
-            factory.provideRemoteAccount(sourceAddress, address(this), expectedAccountAddress);
-        }
-
-        Ownable(expectedAccountAddress).transferOwnership(newOwner);
+        factory.verifyFactoryPrincipalAccount(sourceAddress);
+        Ownable(address(factory)).transferOwnership(instruction.newOwner);
     }
 
     /**
-     * @notice Initialize or replace the successor of this router
-     * @dev Can only be called by the contract owner.
-     *      The new successor may be the zero address to allow reverting to a
-     *      state where no successor is set.
-     *      Any contracts whose ownership has already been transferred to a
-     *      previously designated successor will need to arrange any further
-     *      ownership updates through their new owner.
-     * @param newSuccessor The address designated as the successor router.
+     * @notice Process an enable router instruction
+     * @dev This is an external function which can only be called by this contract.
+     *      Only the factory's principal can enable routers via GMP.
+     *      The router must be vetted first.
+     * @param sourceAddress The principal account address of the factory
+     * @param factoryAddress The expected factory address
+     * @param instruction The decoded EnableRouterInstruction
      */
-    function setSuccessor(address newSuccessor) external onlyOwner {
-        address previousSuccessor = successor;
-        successor = newSuccessor;
-        emit SuccessorSet(previousSuccessor, newSuccessor);
+    function processEnableRouterInstruction(
+        string calldata sourceAddress,
+        address factoryAddress,
+        EnableRouterInstruction calldata instruction
+    ) external override {
+        require(msg.sender == address(this));
+
+        if (factoryAddress != address(factory)) {
+            revert UnauthorizedCaller(sourceAddress);
+        }
+        factory.verifyFactoryPrincipalAccount(sourceAddress);
+
+        factory.enableRouter(instruction.router);
+    }
+
+    /**
+     * @notice Process a disable router instruction
+     * @dev This is an external function which can only be called by this contract.
+     *      Only the factory's principal can disable routers via GMP.
+     * @param sourceAddress The principal account address of the factory
+     * @param factoryAddress The expected factory address
+     * @param instruction The decoded DisableRouterInstruction
+     */
+    function processDisableRouterInstruction(
+        string calldata sourceAddress,
+        address factoryAddress,
+        DisableRouterInstruction calldata instruction
+    ) external override {
+        require(msg.sender == address(this));
+
+        if (factoryAddress != address(factory)) {
+            revert UnauthorizedCaller(sourceAddress);
+        }
+        factory.verifyFactoryPrincipalAccount(sourceAddress);
+
+        factory.disableRouter(instruction.router);
+    }
+
+    /**
+     * @notice Vet a router address
+     * @dev Can only be called by the immutable owner.
+     *      This marks a router as vetted in the factory but does not enable it.
+     *      Enabling must be done separately via a GMP message from the Agoric chain.
+     * @param router The address of the router to vet
+     */
+    function vetRouter(address router) external onlyOwner {
+        factory.vetRouter(router);
+        emit RouterVetted(router);
+    }
+
+    /**
+     * @notice Revoke vetting from a router
+     * @dev Can only be called by the immutable owner.
+     *      The router must be disabled first.
+     * @param router The address of the router to revoke
+     */
+    function revokeRouter(address router) external onlyOwner {
+        factory.revokeRouter(router);
+        emit RouterRevoked(router);
     }
 }

--- a/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountFactory.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountFactory.sol
@@ -31,7 +31,6 @@ contract RemoteAccountFactory is IRemoteAccountFactory {
     error InvalidImplementation(address implementation);
 
     error RouterNotVetted(address router);
-    error RouterNotEnabled(address router);
 
     event RouterVetted(address indexed router);
     event RouterRevoked(address indexed router);
@@ -316,8 +315,9 @@ contract RemoteAccountFactory is IRemoteAccountFactory {
      * @param router The router address to enable
      */
     function _enableRouter(address router) internal {
-        if (_routerStatus[router] != RouterStatus.Vetted) {
-            if (_routerStatus[router] == RouterStatus.Enabled) {
+        RouterStatus status = _routerStatus[router];
+        if (status != RouterStatus.Vetted) {
+            if (status == RouterStatus.Enabled) {
                 return;
             }
             revert RouterNotVetted(router);
@@ -336,11 +336,10 @@ contract RemoteAccountFactory is IRemoteAccountFactory {
         if (router == msg.sender || !isAuthorizedRouter(msg.sender)) {
             revert UnauthorizedCaller(msg.sender);
         }
-        if (_routerStatus[router] != RouterStatus.Enabled) {
-            if (_routerStatus[router] == RouterStatus.Vetted) {
-                return;
-            }
-            revert RouterNotEnabled(router);
+        RouterStatus status = _routerStatus[router];
+        if (status != RouterStatus.Enabled) {
+            assert(status == RouterStatus.Vetted || status == RouterStatus.Unknown);
+            return;
         }
         _routerStatus[router] = RouterStatus.Vetted;
         numberOfAuthorizedRouters -= 1;
@@ -356,8 +355,9 @@ contract RemoteAccountFactory is IRemoteAccountFactory {
         if (msg.sender != vettingAuthority) {
             revert UnauthorizedCaller(msg.sender);
         }
-        if (_routerStatus[router] != RouterStatus.Vetted) {
-            if (_routerStatus[router] == RouterStatus.Unknown) {
+        RouterStatus status = _routerStatus[router];
+        if (status != RouterStatus.Vetted) {
+            if (status == RouterStatus.Unknown) {
                 return;
             }
             revert RouterNotVetted(router);

--- a/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountFactory.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountFactory.sol
@@ -315,6 +315,7 @@ contract RemoteAccountFactory is IRemoteAccountFactory {
             revert UnauthorizedCaller(msg.sender);
         }
         _pendingVettingAuthority = newVettingAuthority;
+        emit VettingAuthorityTransferProposed(msg.sender, newVettingAuthority);
     }
 
     /**

--- a/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountFactory.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountFactory.sol
@@ -15,17 +15,17 @@ import { RemoteAccount } from './RemoteAccount.sol';
  *      The factory uses the EIP-1167 minimal proxy pattern to deploy
  *      the RemoteAccount contracts as "clones", which delegate all calls to a
  *      pre-deployed RemoteAccount implementation contract.
- *      Remote accounts delegate authorization to this factory: any enabled
+ *      Remote accounts delegate authorization to this factory: any authorized
  *      router can execute calls on any account created by this factory.
- *      The factory maintains a vetted/enabled router map to support
+ *      The factory maintains a vetted/authorized router map to support
  *      transitioning to updated routers, while enforcing a 2-factor mechanism
  *      for authorizing new routers.
  */
 contract RemoteAccountFactory is IRemoteAccountFactory {
     enum RouterStatus {
-        Unknown, // Could be potentially revoked
+        Unknown, // Could be potentially unvetted
         Vetted,
-        Enabled // Authorized to operate on remote accounts
+        Authorized // Authorized to operate on remote accounts
     }
 
     error InvalidImplementation(address implementation);
@@ -33,7 +33,7 @@ contract RemoteAccountFactory is IRemoteAccountFactory {
     error RouterNotVetted(address router);
 
     event RouterVetted(address indexed router);
-    event RouterRevoked(address indexed router);
+    event RouterUnvetted(address indexed router);
 
     event VettingAuthorityTransferProposed(
         address indexed currentVettingAuthority,
@@ -61,12 +61,12 @@ contract RemoteAccountFactory is IRemoteAccountFactory {
 
     mapping(address => RouterStatus) private _routerStatus;
 
-    /// @notice The address authorized to vet and revoke routers.
-    /// @dev The vetting authority cannot enable or disable routers, only a
-    //       currently enabled router can. A router cannot be revoked if it is
-    //       still enabled.
+    /// @notice The address authorized to vet and unvet routers.
+    /// @dev The vetting authority cannot authorize or deauthorize routers, only a
+    //       currently authorized router can. A router cannot be unvetted if it is
+    //       still authorized.
     //       Similarly, changing the vetting authority requires the current
-    //       authority to propose a new address, and an enabled router to
+    //       authority to propose a new address, and an authorized router to
     //       confirm the change.
     address public vettingAuthority;
     address private _pendingVettingAuthority;
@@ -76,7 +76,7 @@ contract RemoteAccountFactory is IRemoteAccountFactory {
      * @param factoryPrincipalAccount_ The address of the principal for this RemoteAccountFactory
      * @param implementation_ The address of the pre-deployed RemoteAccount implementation contract.
      *        This implementation must have its initializers disabled to ensure it is inert.
-     * @param initialVettingAuthority_ The initial address authorized to vet and revoke routers
+     * @param initialVettingAuthority_ The initial address authorized to vet and unvet routers
      */
     constructor(
         string memory factoryPrincipalCaip2_,
@@ -249,12 +249,12 @@ contract RemoteAccountFactory is IRemoteAccountFactory {
 
     /**
      * @notice Check if a caller is authorized to operate on remote accounts
-     * @dev Returns true if the caller is an enabled router.
+     * @dev Returns true if the caller is an authorized router.
      * @param caller The address to check
      * @return True if the caller is authorized
      */
     function isAuthorizedRouter(address caller) public view override returns (bool) {
-        return _routerStatus[caller] == RouterStatus.Enabled;
+        return _routerStatus[caller] == RouterStatus.Authorized;
     }
 
     /**
@@ -269,7 +269,7 @@ contract RemoteAccountFactory is IRemoteAccountFactory {
 
     /**
      * @notice Mark a router address as vetted (code-approved)
-     * @dev Only the vetting authority can vet routers. Vetting does not enable the router.
+     * @dev Only the vetting authority can vet routers. Vetting does not authorize the router.
      * @param router The router address to vet
      */
     function vetRouter(address router) public {
@@ -283,10 +283,10 @@ contract RemoteAccountFactory is IRemoteAccountFactory {
     }
 
     /**
-     * @notice Vet and enable the initial router
+     * @notice Vet and authorize the initial router
      * @dev Only the vetting authority can authorize the initial router.
      *      Reverts if the factory is already initialized (any router authorized).
-     * @param router The router address to vet and enable
+     * @param router The router address to vet and authorize
      */
     function vetInitialRouter(address router) external {
         if (numberOfAuthorizedRouters > 0) {
@@ -294,64 +294,64 @@ contract RemoteAccountFactory is IRemoteAccountFactory {
         }
         // This will check that the caller is authorized.
         vetRouter(router);
-        _enableRouter(router);
+        _authorizeRouter(router);
     }
 
     /**
-     * @notice Enable a vetted router to operate on remote accounts
-     * @dev Only an enabled router can enable other routers. Router must be vetted first.
-     * @param router The router address to enable
+     * @notice Authorize a vetted router to operate on remote accounts
+     * @dev Only an authorized router can authorize other routers. Router must be vetted first.
+     * @param router The router address to authorize
      */
-    function enableRouter(address router) external override {
+    function authorizeRouter(address router) external override {
         if (!isAuthorizedRouter(msg.sender)) {
             revert UnauthorizedCaller(msg.sender);
         }
-        _enableRouter(router);
+        _authorizeRouter(router);
     }
 
     /**
-     * @notice Enable a vetted router to operate on remote accounts
+     * @notice Authorize a vetted router to operate on remote accounts
      * @dev The internal caller must ensure the caller is authorized. Router must be vetted first.
-     * @param router The router address to enable
+     * @param router The router address to authorize
      */
-    function _enableRouter(address router) internal {
+    function _authorizeRouter(address router) internal {
         RouterStatus status = _routerStatus[router];
         if (status != RouterStatus.Vetted) {
-            if (status == RouterStatus.Enabled) {
+            if (status == RouterStatus.Authorized) {
                 return;
             }
             revert RouterNotVetted(router);
         }
-        _routerStatus[router] = RouterStatus.Enabled;
+        _routerStatus[router] = RouterStatus.Authorized;
         numberOfAuthorizedRouters += 1;
-        emit RouterEnabled(router, numberOfAuthorizedRouters);
+        emit RouterAuthorized(router, numberOfAuthorizedRouters);
     }
 
     /**
-     * @notice Disable an enabled router
-     * @dev Only an enabled router different from the sender can disable
-     * @param router The router address to disable
+     * @notice Deauthorize an authorized router
+     * @dev Only an authorized router different from the sender can deauthorize
+     * @param router The router address to deauthorize
      */
-    function disableRouter(address router) external override {
+    function deauthorizeRouter(address router) external override {
         if (router == msg.sender || !isAuthorizedRouter(msg.sender)) {
             revert UnauthorizedCaller(msg.sender);
         }
         RouterStatus status = _routerStatus[router];
-        if (status != RouterStatus.Enabled) {
+        if (status != RouterStatus.Authorized) {
             assert(status == RouterStatus.Vetted || status == RouterStatus.Unknown);
             return;
         }
         _routerStatus[router] = RouterStatus.Vetted;
         numberOfAuthorizedRouters -= 1;
-        emit RouterDisabled(router, numberOfAuthorizedRouters);
+        emit RouterDeauthorized(router, numberOfAuthorizedRouters);
     }
 
     /**
-     * @notice Revoke vetting from a router
-     * @dev Only the vetting authority can revoke. Router must be disabled first.
-     * @param router The router address to revoke
+     * @notice Unvet a router
+     * @dev Only the vetting authority can unvet. Router must be deauthorized first.
+     * @param router The router address to unvet
      */
-    function revokeRouter(address router) external {
+    function unvetRouter(address router) external {
         if (msg.sender != vettingAuthority) {
             revert UnauthorizedCaller(msg.sender);
         }
@@ -363,13 +363,13 @@ contract RemoteAccountFactory is IRemoteAccountFactory {
             revert RouterNotVetted(router);
         }
         delete _routerStatus[router];
-        emit RouterRevoked(router);
+        emit RouterUnvetted(router);
     }
 
     /**
      * @notice Propose transfer of vetting authority to a new address
      * @dev Only the current vetting authority can propose a new address.
-     *      The proposed address must be confirmed via an enabled router to
+     *      The proposed address must be confirmed via an authorized router to
      *      become the new vetting authority.
      * @param newVettingAuthority The address of the new vetting authority
      */
@@ -383,7 +383,7 @@ contract RemoteAccountFactory is IRemoteAccountFactory {
 
     /**
      * @notice Confirm transfer of vetting authority to the proposed address
-     * @dev Only an enabled router can confirm. The address must match the
+     * @dev Only an authorized router can confirm. The address must match the
      *      previously proposed address.
      * @param newVettingAuthority The address of the new vetting authority (must be proposed first)
      */

--- a/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountFactory.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountFactory.sol
@@ -15,17 +15,17 @@ import { RemoteAccount } from './RemoteAccount.sol';
  *      The factory uses the EIP-1167 minimal proxy pattern to deploy
  *      the RemoteAccount contracts as "clones", which delegate all calls to a
  *      pre-deployed RemoteAccount implementation contract.
- *      Remote accounts delegate ownership transitively through this factory:
- *      any enabled router can execute calls on any account created by this
- *      factory.
- *      The factory also maintains a vetted/enabled router map to support
- *      experimental routers alongside the primary router.
+ *      Remote accounts delegate authorization to this factory: any enabled
+ *      router can execute calls on any account created by this factory.
+ *      The factory maintains a vetted/enabled router map to support
+ *      transitioning to updated routers, while enforcing a 2-factor mechanism
+ *      for authorizing new routers.
  */
 contract RemoteAccountFactory is IRemoteAccountFactory {
     enum RouterStatus {
         Unknown, // Could be potentially revoked
         Vetted,
-        Enabled
+        Enabled // Authorized to operate on remote accounts
     }
 
     error RouterNotVetted(address router);
@@ -46,13 +46,16 @@ contract RemoteAccountFactory is IRemoteAccountFactory {
 
     // Store the principal details of this factory purely for reference
     // Immutable, but cannot be declaratively marked as such because they are strings
+    /// @notice The CAIP-2 chain identifier for the factory's principal
     string public factoryPrincipalCaip2;
+    /// @notice The account identifier for the factory's principal
     string public factoryPrincipalAccount;
 
     bytes32 private immutable _principalSalt;
     /// @notice The pre-deployed RemoteAccount implementation that all clones delegate to
     address public immutable implementation;
 
+    /// @notice The number of routers currently authorized to operate remote accounts created by this factory
     uint256 public numberOfAuthorizedRouters;
 
     mapping(address => RouterStatus) private _routerStatus;
@@ -196,8 +199,9 @@ contract RemoteAccountFactory is IRemoteAccountFactory {
     /**
      * @notice Provide a RemoteAccount - creates if new, verifies if exists
      * @dev Idempotent: calling multiple times with same params is safe.
-     *      Since accounts delegate ownership through this factory, there is no
-     *      per-account owner to verify — any authorized caller can operate any account.
+     *      Since accounts immutably delegate authorization through this factory,
+     *      there is no account state to verify (we rely on deterministic address
+     *      derivation of the remote accounts, and atomic initialization).
      * @param principalAccount The principal account string for the RemoteAccount
      * @param expectedAddress The expected CREATE2 address (for verification)
      * @return created true if the RemoteAccount was created, false if it was pre-existing
@@ -232,7 +236,7 @@ contract RemoteAccountFactory is IRemoteAccountFactory {
         assert(newAccountAddress == expectedAddress);
 
         // Initialize the clone with this factory's address.
-        // The clone resolves ownership transitively through this factory.
+        // The clone immutably delegates authorization to this factory.
         RemoteAccount(payable(newAccountAddress)).initialize(address(this));
 
         emit RemoteAccountCreated(newAccountAddress, principalAccount);
@@ -276,7 +280,7 @@ contract RemoteAccountFactory is IRemoteAccountFactory {
     /**
      * @notice Vet and enable the initial router
      * @dev Only the vetting authority can authorize the initial router.
-     *      Reverts if already initialized (any router authorized).
+     *      Reverts if the factory is already initialized (any router authorized).
      * @param router The router address to vet and enable
      */
     function vetInitialRouter(address router) external {
@@ -356,6 +360,13 @@ contract RemoteAccountFactory is IRemoteAccountFactory {
         emit RouterRevoked(router);
     }
 
+    /**
+     * @notice Propose transfer of vetting authority to a new address
+     * @dev Only the current vetting authority can propose a new address.
+     *      The proposed address must be confirmed via an enabled router to
+     *      become the new vetting authority.
+     * @param newVettingAuthority The address of the new vetting authority
+     */
     function proposeVettingAuthorityTransfer(address newVettingAuthority) external {
         if (msg.sender != vettingAuthority) {
             revert UnauthorizedCaller(msg.sender);
@@ -366,7 +377,8 @@ contract RemoteAccountFactory is IRemoteAccountFactory {
 
     /**
      * @notice Confirm transfer of vetting authority to the proposed address
-     * @dev Only an enabled router can confirm.
+     * @dev Only an enabled router can confirm. The address must match the
+     *      previously proposed address.
      * @param newVettingAuthority The address of the new vetting authority (must be proposed first)
      */
     function confirmVettingAuthorityTransfer(address newVettingAuthority) external override {

--- a/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountFactory.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountFactory.sol
@@ -25,7 +25,7 @@ import { RemoteAccount } from './RemoteAccount.sol';
  *      The factory also maintains a vetted/enabled router map to support
  *      experimental routers alongside the main owner.
  */
-contract RemoteAccountFactory is Ownable, IRemoteAccountFactory {
+contract RemoteAccountFactory is IRemoteAccountFactory {
     // Store the principal details of this factory purely for reference
     // Immutable, but cannot be declaratively marked as such because they are strings
     string public factoryPrincipalCaip2;
@@ -35,27 +35,59 @@ contract RemoteAccountFactory is Ownable, IRemoteAccountFactory {
     /// @notice The pre-deployed RemoteAccount implementation that all clones delegate to
     address public immutable implementation;
 
-    /// @dev Routers that have been vetted by the factory owner
-    mapping(address => bool) private _vetted;
-    /// @dev Routers that have been enabled (active) — must be vetted first
-    mapping(address => bool) private _enabled;
+    mapping(address => RouterStatus) private _routerStatus;
+
+    /// @notice The address authorized to vet and revoke routers.
+    /// @dev The vetting authority cannot enable or disable routers, only a
+    //       currently enabled router can. A router cannot be revoked if it is
+    //       still enabled.
+    //       Similarly, changing the vetting authority requires the current
+    //       authority to propose a new address, and an enabled router to
+    //       confirm the change.
+    address public vettingAuthority;
+    address private _pendingVettingAuthority;
 
     /**
      * @param factoryPrincipalCaip2_ The caip2 of the principal for this RemoteAccountFactory
      * @param factoryPrincipalAccount_ The address of the principal for this RemoteAccountFactory
      * @param implementation_ The address of the pre-deployed RemoteAccount implementation contract.
      *        This implementation must have its initializers disabled to ensure it is inert.
+     * @param initialRouter The initial router to enable
+     * @param vettingAuthority_ The address authorized to vet and revoke routers
      */
     constructor(
         string memory factoryPrincipalCaip2_,
         string memory factoryPrincipalAccount_,
-        address implementation_
-    ) Ownable(_msgSender()) {
+        address implementation_,
+        address initialRouter,
+        address vettingAuthority_
+    ) {
         factoryPrincipalCaip2 = factoryPrincipalCaip2_;
         factoryPrincipalAccount = factoryPrincipalAccount_;
-        _principalSalt = keccak256(bytes(factoryPrincipalAccount_));
+        _principalSalt = keccak256(bytes(factoryPrincipalAccount_)); // _getSalt(factoryPrincipalAccount_);
         implementation = implementation_;
-        require(implementation_.code.length > 0, 'Implementation must be a contract');
+        _routerStatus[initialRouter] = RouterStatus.Enabled;
+        emit RouterVetted(initialRouter);
+        emit RouterEnabled(initialRouter);
+        if (vettingAuthority_ == address(0)) {
+            vettingAuthority = msg.sender;
+        } else {
+            vettingAuthority = vettingAuthority_;
+        }
+
+        // The initial router must be vetted and enabled by the constructor since there is no owner to call vetRouter or enableRouter.
+        try RemoteAccount(payable(implementation_)).factory() returns (address implFactory) {
+            if (implFactory != address(0)) {
+                revert('Implementation must be an inert RemoteAccount contract');
+            }
+        } catch {
+            revert('Implementation must be a RemoteAccount contract');
+        }
+        try RemoteAccount(payable(implementation_)).initialize(address(0)) {
+            revert('Implementation must be an inert RemoteAccount contract');
+        } catch {
+            // Expected to revert because the implementation should have initializers disabled
+        }
     }
 
     function _getSalt(string calldata principalAccount) internal pure returns (bytes32) {
@@ -146,19 +178,8 @@ contract RemoteAccountFactory is Ownable, IRemoteAccountFactory {
     }
 
     /**
-     * @notice Check if a caller is authorized to operate on remote accounts
-     * @dev Returns true if the caller is the current factory owner or an enabled router.
-     * @param caller The address to check
-     * @return True if the caller is authorized
-     */
-    function isAuthorizedCaller(address caller) external view override returns (bool) {
-        return caller == owner() || _enabled[caller];
-    }
-
-    /**
      * @notice Provide a RemoteAccount - creates if new, verifies if exists
      * @dev Idempotent: calling multiple times with same params is safe.
-     *      Only authorized callers (factory owner or enabled routers) can create new accounts.
      *      Since accounts delegate ownership through this factory, there is no
      *      per-account owner to verify — any authorized caller can operate any account.
      * @param principalAccount The principal account string for the RemoteAccount
@@ -175,88 +196,8 @@ contract RemoteAccountFactory is Ownable, IRemoteAccountFactory {
             return false;
         }
 
-        if (msg.sender != owner() && !_enabled[msg.sender]) {
-            revert UnauthorizedCaller(msg.sender);
-        }
-
         _createRemoteAccount(principalAccount, salt, expectedAddress);
         return true;
-    }
-
-    /**
-     * @notice Mark a router address as vetted (code-approved)
-     * @dev Only the factory owner can vet routers. Vetting does not enable the router.
-     * @param router The router address to vet
-     */
-    function vetRouter(address router) external override onlyOwner {
-        _vetted[router] = true;
-        emit RouterVetted(router);
-    }
-
-    /**
-     * @notice Enable a vetted router to operate on remote accounts
-     * @dev Only the factory owner can enable routers. Router must be vetted first.
-     * @param router The router address to enable
-     */
-    function enableRouter(address router) external override onlyOwner {
-        if (!_vetted[router]) {
-            revert RouterNotVetted(router);
-        }
-        _enabled[router] = true;
-        emit RouterEnabled(router);
-    }
-
-    /**
-     * @notice Disable an enabled router
-     * @dev Only the factory owner can disable routers.
-     * @param router The router address to disable
-     */
-    function disableRouter(address router) external override onlyOwner {
-        _enabled[router] = false;
-        emit RouterDisabled(router);
-    }
-
-    /**
-     * @notice Revoke vetting from a router
-     * @dev Only the factory owner can revoke. Router must be disabled first.
-     * @param router The router address to revoke
-     */
-    function revokeRouter(address router) external override onlyOwner {
-        if (_enabled[router]) {
-            revert RouterStillEnabled(router);
-        }
-        _vetted[router] = false;
-        emit RouterRevoked(router);
-    }
-
-    /**
-     * @notice Transfer factory ownership to a new owner
-     * @dev Overrides Ownable.transferOwnership to require the new owner is vetted.
-     *      Setting a new owner automatically enables it.
-     *      XXX The previous owner stays enabled to support concurrent multi-router
-     *      operation. The caller must explicitly disableRouter the old owner via
-     *      GMP if it should no longer be authorized.
-     * @param newOwner The address of the new owner (must be vetted)
-     */
-    function transferOwnership(address newOwner) public override onlyOwner {
-        if (!_vetted[newOwner]) {
-            revert RouterNotVetted(newOwner);
-        }
-        _enabled[newOwner] = true;
-        super.transferOwnership(newOwner);
-    }
-
-    /**
-     * @notice Disabled — renouncing ownership would brick every RemoteAccount.
-     * @dev All remote accounts delegate authorization through this factory via
-     *      isAuthorizedCaller. If ownership is renounced, owner() becomes
-     *      address(0) and all onlyOwner functions (vetRouter, enableRouter,
-     *      disableRouter, transferOwnership) are permanently locked. Any
-     *      currently enabled routers could never be rotated or disabled,
-     *      and if none are enabled, every account becomes inoperable.
-     */
-    function renounceOwnership() public pure override {
-        revert();
     }
 
     /**
@@ -279,5 +220,124 @@ contract RemoteAccountFactory is Ownable, IRemoteAccountFactory {
         RemoteAccount(payable(newAccountAddress)).initialize(address(this));
 
         emit RemoteAccountCreated(newAccountAddress, principalAccount);
+    }
+
+    /**
+     * @notice Check if a caller is authorized to operate on remote accounts
+     * @dev Returns true if the caller is an enabled router.
+     * @param caller The address to check
+     * @return True if the caller is authorized
+     */
+    function isAuthorizedRouter(address caller) public view override returns (bool) {
+        return _routerStatus[caller] == RouterStatus.Enabled;
+    }
+
+    /**
+     * @notice Check the status of a router
+     * @dev Returns the current status of the router.
+     * @param router The address to check
+     * @return The status of the router
+     */
+    function getRouterStatus(address router) external view override returns (RouterStatus) {
+        return _routerStatus[router];
+    }
+
+    /**
+     * @notice Mark a router address as vetted (code-approved)
+     * @dev Only the vetting authority can vet routers. Vetting does not enable the router.
+     * @param router The router address to vet
+     */
+    function vetRouter(address router) external {
+        if (msg.sender != vettingAuthority) {
+            revert UnauthorizedCaller(msg.sender);
+        }
+        if (_routerStatus[router] == RouterStatus.Unknown) {
+            _routerStatus[router] = RouterStatus.Vetted;
+            emit RouterVetted(router);
+        }
+    }
+
+    /**
+     * @notice Enable a vetted router to operate on remote accounts
+     * @dev Only an enabled router can enable other routers. Router must be vetted first.
+     * @param router The router address to enable
+     */
+    function enableRouter(address router) external override {
+        if (!isAuthorizedRouter(msg.sender)) {
+            revert UnauthorizedCaller(msg.sender);
+        }
+        if (_routerStatus[router] != RouterStatus.Vetted) {
+            if (_routerStatus[router] == RouterStatus.Enabled) {
+                return;
+            }
+            revert RouterNotVetted(router);
+        }
+        _routerStatus[router] = RouterStatus.Enabled;
+        emit RouterEnabled(router);
+    }
+
+    /**
+     * @notice Disable an enabled router
+     * @dev Only an enabled router different from the sender can disable
+     * @param router The router address to disable
+     */
+    function disableRouter(address router) external override {
+        if (router == msg.sender || !isAuthorizedRouter(msg.sender)) {
+            revert UnauthorizedCaller(msg.sender);
+        }
+        if (_routerStatus[router] != RouterStatus.Enabled) {
+            if (_routerStatus[router] == RouterStatus.Vetted) {
+                return;
+            }
+            revert RouterNotEnabled(router);
+        }
+        _routerStatus[router] = RouterStatus.Vetted;
+        emit RouterDisabled(router);
+    }
+
+    /**
+     * @notice Revoke vetting from a router
+     * @dev Only the vetting authority can revoke. Router must be disabled first.
+     * @param router The router address to revoke
+     */
+    function revokeRouter(address router) external {
+        if (msg.sender != vettingAuthority) {
+            revert UnauthorizedCaller(msg.sender);
+        }
+        if (_routerStatus[router] != RouterStatus.Vetted) {
+            if (_routerStatus[router] == RouterStatus.Unknown) {
+                return;
+            }
+            revert RouterNotVetted(router);
+        }
+        delete _routerStatus[router];
+        emit RouterRevoked(router);
+    }
+
+    function proposeVettingAuthorityTransfer(address newVettingAuthority) external {
+        if (msg.sender != vettingAuthority) {
+            revert UnauthorizedCaller(msg.sender);
+        }
+        _pendingVettingAuthority = newVettingAuthority;
+    }
+
+    /**
+     * @notice Confirm transfer of vetting authority to the proposed address
+     * @dev Only an enabled router can confirm.
+     * @param newVettingAuthority The address of the new vetting authority (must be proposed first)
+     */
+    function confirmVettingAuthorityTransfer(address newVettingAuthority) external override {
+        if (!isAuthorizedRouter(msg.sender)) {
+            revert UnauthorizedCaller(msg.sender);
+        }
+        if (newVettingAuthority != _pendingVettingAuthority || newVettingAuthority == address(0)) {
+            revert InvalidVettingAuthority(newVettingAuthority, _pendingVettingAuthority);
+        }
+
+        address previousVettingAuthority = vettingAuthority;
+        vettingAuthority = newVettingAuthority;
+        _pendingVettingAuthority = address(0);
+
+        emit VettingAuthorityTransferred(previousVettingAuthority, newVettingAuthority);
     }
 }

--- a/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountFactory.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountFactory.sol
@@ -202,6 +202,10 @@ contract RemoteAccountFactory is IRemoteAccountFactory {
      *      Since accounts immutably delegate authorization through this factory,
      *      there is no account state to verify (we rely on deterministic address
      *      derivation of the remote accounts, and atomic initialization).
+     *      This method is intentionally public as the created remote account is
+     *      intrinsically tied to its principal and this factory. No other party
+     *      than the designated principal can operate the account, and only
+     *      through an authorized router.
      * @param principalAccount The principal account string for the RemoteAccount
      * @param expectedAddress The expected CREATE2 address (for verification)
      * @return created true if the RemoteAccount was created, false if it was pre-existing

--- a/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountFactory.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountFactory.sol
@@ -22,6 +22,28 @@ import { RemoteAccount } from './RemoteAccount.sol';
  *      experimental routers alongside the primary router.
  */
 contract RemoteAccountFactory is IRemoteAccountFactory {
+    enum RouterStatus {
+        Unknown, // Could be potentially revoked
+        Vetted,
+        Enabled
+    }
+
+    error RouterNotVetted(address router);
+    error RouterNotEnabled(address router);
+
+    event RouterVetted(address indexed router);
+    event RouterRevoked(address indexed router);
+
+    event VettingAuthorityTransferProposed(
+        address indexed currentVettingAuthority,
+        address indexed proposedVettingAuthority
+    );
+
+    event VettingAuthorityTransferred(
+        address indexed previousVettingAuthority,
+        address indexed newVettingAuthority
+    );
+
     // Store the principal details of this factory purely for reference
     // Immutable, but cannot be declaratively marked as such because they are strings
     string public factoryPrincipalCaip2;
@@ -232,7 +254,7 @@ contract RemoteAccountFactory is IRemoteAccountFactory {
      * @param router The address to check
      * @return The status of the router
      */
-    function getRouterStatus(address router) external view override returns (RouterStatus) {
+    function getRouterStatus(address router) external view returns (RouterStatus) {
         return _routerStatus[router];
     }
 

--- a/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountFactory.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountFactory.sol
@@ -28,6 +28,8 @@ contract RemoteAccountFactory is IRemoteAccountFactory {
         Enabled // Authorized to operate on remote accounts
     }
 
+    error InvalidImplementation(address implementation);
+
     error RouterNotVetted(address router);
     error RouterNotEnabled(address router);
 
@@ -97,13 +99,13 @@ contract RemoteAccountFactory is IRemoteAccountFactory {
 
         try RemoteAccount(payable(implementation_)).factory() returns (address implFactory) {
             if (implFactory != address(0)) {
-                revert('Implementation must be an inert RemoteAccount contract');
+                revert InvalidImplementation(implementation_);
             }
         } catch {
-            revert('Implementation must be a RemoteAccount contract');
+            revert InvalidImplementation(implementation_);
         }
         try RemoteAccount(payable(implementation_)).initialize(address(0), '') {
-            revert('Implementation must be an inert RemoteAccount contract');
+            revert InvalidImplementation(implementation_);
         } catch {
             // Expected to revert because the implementation should have initializers disabled
         }

--- a/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountFactory.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountFactory.sol
@@ -247,6 +247,19 @@ contract RemoteAccountFactory is Ownable, IRemoteAccountFactory {
     }
 
     /**
+     * @notice Disabled — renouncing ownership would brick every RemoteAccount.
+     * @dev All remote accounts delegate authorization through this factory via
+     *      isAuthorizedCaller. If ownership is renounced, owner() becomes
+     *      address(0) and all onlyOwner functions (vetRouter, enableRouter,
+     *      disableRouter, transferOwnership) are permanently locked. Any
+     *      currently enabled routers could never be rotated or disabled,
+     *      and if none are enabled, every account becomes inoperable.
+     */
+    function renounceOwnership() public pure override {
+        revert();
+    }
+
+    /**
      * @notice Create a RemoteAccount clone
      * @dev Deploys an EIP-1167 clone and initializes it with this factory's address.
      * @param principalAccount The principal account string for the RemoteAccount

--- a/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountFactory.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountFactory.sol
@@ -19,15 +19,11 @@ import { RemoteAccount } from './RemoteAccount.sol';
  *      This factory is ownable, and at any point in time is expected to be
  *      owned by the active representative of that factory principal (such as an
  *      IRemoteAccountRouter).
- *      This factory can be invoked publicly to create a RemoteAccount for a
- *      principal account string, initialized with an owner matching the current
- *      owner of this factory.
- *      This factory can also be invoked by its current owner to create such a
- *      RemoteAccount with an arbitrary owner.
- *      Each RemoteAccount created by this factory is uniquely identified by its
- *      principal account string via deterministic CREATE2 address derivation
- *      of the EIP-1167 proxy bytecode
- *      (see https://eips.ethereum.org/EIPS/eip-1167).
+ *      Remote accounts delegate ownership transitively through this factory:
+ *      any caller authorized by the factory (its current owner or an enabled
+ *      router) can execute calls on any account created by this factory.
+ *      The factory also maintains a vetted/enabled router map to support
+ *      experimental routers alongside the main owner.
  */
 contract RemoteAccountFactory is Ownable, IRemoteAccountFactory {
     // Store the principal details of this factory purely for reference
@@ -39,11 +35,16 @@ contract RemoteAccountFactory is Ownable, IRemoteAccountFactory {
     /// @notice The pre-deployed RemoteAccount implementation that all clones delegate to
     address public immutable implementation;
 
+    /// @dev Routers that have been vetted by the factory owner
+    mapping(address => bool) private _vetted;
+    /// @dev Routers that have been enabled (active) — must be vetted first
+    mapping(address => bool) private _enabled;
+
     /**
      * @param factoryPrincipalCaip2_ The caip2 of the principal for this RemoteAccountFactory
      * @param factoryPrincipalAccount_ The address of the principal for this RemoteAccountFactory
      * @param implementation_ The address of the pre-deployed RemoteAccount implementation contract.
-     *        This implementation must have its ownership renounced to ensure it is inert.
+     *        This implementation must have its initializers disabled to ensure it is inert.
      */
     constructor(
         string memory factoryPrincipalCaip2_,
@@ -52,9 +53,9 @@ contract RemoteAccountFactory is Ownable, IRemoteAccountFactory {
     ) Ownable(_msgSender()) {
         factoryPrincipalCaip2 = factoryPrincipalCaip2_;
         factoryPrincipalAccount = factoryPrincipalAccount_;
-        _principalSalt = keccak256(bytes(factoryPrincipalAccount_)); // _getSalt(factoryPrincipalAccount_);
+        _principalSalt = keccak256(bytes(factoryPrincipalAccount_));
         implementation = implementation_;
-        _verifyRemoteAccountOwner(implementation_, address(0));
+        require(implementation_.code.length > 0, 'Implementation must be a contract');
     }
 
     function _getSalt(string calldata principalAccount) internal pure returns (bytes32) {
@@ -88,7 +89,6 @@ contract RemoteAccountFactory is Ownable, IRemoteAccountFactory {
     ) internal view returns (address, bytes32) {
         bytes32 salt = _getSalt(principalAccount);
         if (salt == _principalSalt) {
-            // XXX address(0) would also be an acceptable argument
             revert InvalidAccountAtAddress(address(this));
         }
         return (Clones.predictDeterministicAddress(implementation, salt), salt);
@@ -107,28 +107,9 @@ contract RemoteAccountFactory is Ownable, IRemoteAccountFactory {
     }
 
     /**
-     * @notice Check if a RemoteAccount with the expected owner exists at the given address
-     * @dev Assumes the caller already derived the account address from the principal account,
-     *      and verified code exists for the address.
-     *      Checks that the owner matches.
-     *      Does not check that contract is a RemoteAccount, relies on deterministic address derivation.
-     * @param accountAddress The derived remote account address to check
-     * @param owner The expected address of the account's current owner
-     */
-    function _verifyRemoteAccountOwner(address accountAddress, address owner) internal view {
-        try RemoteAccount(payable(accountAddress)).owner() returns (address existingOwner) {
-            if (existingOwner != owner) {
-                revert UnauthorizedOwner(owner, accountAddress);
-            }
-        } catch {
-            revert UnauthorizedOwner(owner, accountAddress);
-        }
-    }
-
-    /**
      * @notice Verify an address is the expected one for a remote account
      *         created by this factory given its principal.
-     * @dev Does not perform any ownership or existence checks.
+     * @dev Does not perform any existence checks.
      *      Reverts if the account address does not match the expected address derived from the principal,
      *      or if the factory's principal is used.
      * @param principalAccount The address of the principal for the RemoteAccount
@@ -138,7 +119,7 @@ contract RemoteAccountFactory is Ownable, IRemoteAccountFactory {
     function _verifyRemoteAccountAddress(
         string calldata principalAccount,
         address expectedAccountAddress
-    ) public view returns (bytes32 salt) {
+    ) internal view returns (bytes32 salt) {
         address actualAccountAddress;
         (actualAccountAddress, salt) = _getRemoteAccountAddress(principalAccount);
         if (actualAccountAddress != expectedAccountAddress) {
@@ -147,18 +128,14 @@ contract RemoteAccountFactory is Ownable, IRemoteAccountFactory {
     }
 
     /**
-     * @notice Verify an address is a remote account for a given principal and its owner matches
-     * @dev Does not check the owner matches the factory's current owner to allow a non current owner
-     *      to interact with remote accounts whose ownership needs to be updated.
-     *      Reverts if the account address does not match the expected address derived from the principal.
-     *      Reverts if there is no account at the address, or it does not have the expected owner.
+     * @notice Verify an address is a remote account for a given principal
+     * @dev Reverts if the account address does not match the expected address derived from the principal.
+     *      Reverts if there is no account at the address.
      * @param principalAccount The address of the principal for the RemoteAccount
-     * @param expectedOwner The expected address of the owner
      * @param expectedAccountAddress The expected address to verify
      */
     function verifyRemoteAccount(
         string calldata principalAccount,
-        address expectedOwner,
         address expectedAccountAddress
     ) public view override {
         _verifyRemoteAccountAddress(principalAccount, expectedAccountAddress);
@@ -166,109 +143,125 @@ contract RemoteAccountFactory is Ownable, IRemoteAccountFactory {
         if (expectedAccountAddress.code.length == 0) {
             revert InvalidAccountAtAddress(expectedAccountAddress);
         }
+    }
 
-        _verifyRemoteAccountOwner(expectedAccountAddress, expectedOwner);
+    /**
+     * @notice Check if a caller is authorized to operate on remote accounts
+     * @dev Returns true if the caller is the current factory owner or an enabled router.
+     * @param caller The address to check
+     * @return True if the caller is authorized
+     */
+    function isAuthorizedCaller(address caller) external view override returns (bool) {
+        return caller == owner() || _enabled[caller];
     }
 
     /**
      * @notice Provide a RemoteAccount - creates if new, verifies if exists
-     * @dev Idempotent: calling multiple times with same params is safe as
-     *      long as the current owner matches between the factory and remote account.
-     *
-     *      The expectedOwner parameter is critical for safety:
-     *      - TOCTOU: Prevents time-of-check time-of-use races where the caller checks
-     *        owner() then calls provideRemoteAccount(), but ownership changes in between. By validating
-     *        expectedOwner matches current owner at execution, caller intent is preserved.
-     *
-     *      - Router upgrades: When upgrading from router A to B, in-flight provideRemoteAccount() calls
-     *        meant for router A will fail rather than creating accounts owned by router B.
-     *
-     *      - Reorgs: During blockchain reorganizations, if a router ownership transfer and
-     *        provideRemoteAccount() call get reordered, the check ensures provideRemoteAccount() fails rather than
-     *        creating accounts with unexpected ownership.
-     *
+     * @dev Idempotent: calling multiple times with same params is safe.
+     *      Only authorized callers (factory owner or enabled routers) can create new accounts.
+     *      Since accounts delegate ownership through this factory, there is no
+     *      per-account owner to verify — any authorized caller can operate any account.
      * @param principalAccount The principal account string for the RemoteAccount
-     * @param expectedOwner The expected address of the owner, must be current owner of the factory
      * @param expectedAddress The expected CREATE2 address (for verification)
      * @return created true if the RemoteAccount was created, false if it was pre-existing
      */
     function provideRemoteAccount(
         string calldata principalAccount,
-        address expectedOwner,
         address expectedAddress
     ) external override returns (bool) {
         bytes32 salt = _verifyRemoteAccountAddress(principalAccount, expectedAddress);
 
         if (expectedAddress.code.length != 0) {
-            _verifyRemoteAccountOwner(expectedAddress, expectedOwner);
             return false;
-        } else if (owner() == expectedOwner) {
-            _createRemoteAccountForOwner(principalAccount, salt, expectedOwner, expectedAddress);
-            return true;
-        } else {
-            // The public method cannot be used to provide a remote account for
-            // a different owner, to prevent potential denial of service where
-            // an attacker would create an inaccessible remote account.
-            revert UnauthorizedOwner(expectedOwner, expectedAddress);
         }
+
+        if (msg.sender != owner() && !_enabled[msg.sender]) {
+            revert UnauthorizedCaller(msg.sender);
+        }
+
+        _createRemoteAccount(principalAccount, salt, expectedAddress);
+        return true;
     }
 
     /**
-     * @notice Provide a RemoteAccount - creates if new, verifies if exists
-     * @dev Idempotent: calling multiple times with same params succeeds as
-     *      long as the RemoteAccount's current owner matches the provided ownerAddress.
-     *      This allows the owner router to provide an account with a specific
-     *      owner address. The owner is expected to call this function only for
-     *      experimentation before committing to its own successor.
-     * @param principalAccount The principal account string for the RemoteAccount
-     * @param ownerAddress The address to use as owner of the RemoteAccount
-     * @param expectedAddress The expected CREATE2 address (for verification)
-     * @return created true if the RemoteAccount was created, false if it was pre-existing
+     * @notice Mark a router address as vetted (code-approved)
+     * @dev Only the factory owner can vet routers. Vetting does not enable the router.
+     * @param router The router address to vet
      */
-    function provideRemoteAccountForOwner(
-        string calldata principalAccount,
-        address ownerAddress,
-        address expectedAddress
-    ) external override onlyOwner returns (bool created) {
-        bytes32 salt = _verifyRemoteAccountAddress(principalAccount, expectedAddress);
-
-        if (expectedAddress.code.length != 0) {
-            // If the account already exists, we can only verify its owner matches the requested one
-            _verifyRemoteAccountOwner(expectedAddress, ownerAddress);
-            return false;
-        } else {
-            _createRemoteAccountForOwner(principalAccount, salt, ownerAddress, expectedAddress);
-            return true;
-        }
+    function vetRouter(address router) external override onlyOwner {
+        _vetted[router] = true;
+        emit RouterVetted(router);
     }
 
     /**
-     * @notice Create a RemoteAccount - creates if new
-     * @dev This accepts any owner. The external function must control owner
-     *      address usage as it may prevent the portfolio manager from reaching
-     *      the RemoteAccount if it does not have access to that router owner.
+     * @notice Enable a vetted router to operate on remote accounts
+     * @dev Only the factory owner can enable routers. Router must be vetted first.
+     * @param router The router address to enable
+     */
+    function enableRouter(address router) external override onlyOwner {
+        if (!_vetted[router]) {
+            revert RouterNotVetted(router);
+        }
+        _enabled[router] = true;
+        emit RouterEnabled(router);
+    }
+
+    /**
+     * @notice Disable an enabled router
+     * @dev Only the factory owner can disable routers.
+     * @param router The router address to disable
+     */
+    function disableRouter(address router) external override onlyOwner {
+        _enabled[router] = false;
+        emit RouterDisabled(router);
+    }
+
+    /**
+     * @notice Revoke vetting from a router
+     * @dev Only the factory owner can revoke. Router must be disabled first.
+     * @param router The router address to revoke
+     */
+    function revokeRouter(address router) external override onlyOwner {
+        if (_enabled[router]) {
+            revert RouterStillEnabled(router);
+        }
+        _vetted[router] = false;
+        emit RouterRevoked(router);
+    }
+
+    /**
+     * @notice Transfer factory ownership to a new owner
+     * @dev Overrides Ownable.transferOwnership to require the new owner is vetted.
+     *      Setting a new owner automatically enables it.
+     * @param newOwner The address of the new owner (must be vetted)
+     */
+    function transferOwnership(address newOwner) public override onlyOwner {
+        if (!_vetted[newOwner]) {
+            revert RouterNotVetted(newOwner);
+        }
+        _enabled[newOwner] = true;
+        super.transferOwnership(newOwner);
+    }
+
+    /**
+     * @notice Create a RemoteAccount clone
+     * @dev Deploys an EIP-1167 clone and initializes it with this factory's address.
      * @param principalAccount The principal account string for the RemoteAccount
-     * @param salt the CREATE2 salt for the remote account that has been derived
-     *        from the principal account
-     * @param ownerAddress The address to use as owner of the RemoteAccount
+     * @param salt the CREATE2 salt derived from the principal account
      * @param expectedAddress The expected CREATE2 address (for verification)
      */
-    function _createRemoteAccountForOwner(
+    function _createRemoteAccount(
         string calldata principalAccount,
         bytes32 salt,
-        address ownerAddress,
         address expectedAddress
     ) internal {
-        // Do not include the owner address to keep the remote account address independent
-        // from its current owner setup.
         address newAccountAddress = Clones.cloneDeterministic(implementation, salt);
         assert(newAccountAddress == expectedAddress);
 
-        // Initialize ownership on the clone. Clones do not run
-        // constructors, so _owner starts as address(0). The initialize
-        // function can only be called once and sets the owner.
-        RemoteAccount(payable(newAccountAddress)).initialize(ownerAddress);
+        // Initialize the clone with this factory's address.
+        // The clone resolves ownership transitively through this factory.
+        RemoteAccount(payable(newAccountAddress)).initialize(address(this));
 
-        emit RemoteAccountCreated(newAccountAddress, principalAccount, ownerAddress);
+        emit RemoteAccountCreated(newAccountAddress, principalAccount);
     }
 }

--- a/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountFactory.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountFactory.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.20;
 
 import { Clones } from '@openzeppelin/contracts/proxy/Clones.sol';
-import { Ownable } from '@openzeppelin/contracts/access/Ownable.sol';
 import { IRemoteAccountFactory } from './interfaces/IRemoteAccountFactory.sol';
 import { RemoteAccount } from './RemoteAccount.sol';
 
@@ -16,14 +15,11 @@ import { RemoteAccount } from './RemoteAccount.sol';
  *      The factory uses the EIP-1167 minimal proxy pattern to deploy
  *      the RemoteAccount contracts as "clones", which delegate all calls to a
  *      pre-deployed RemoteAccount implementation contract.
- *      This factory is ownable, and at any point in time is expected to be
- *      owned by the active representative of that factory principal (such as an
- *      IRemoteAccountRouter).
  *      Remote accounts delegate ownership transitively through this factory:
- *      any caller authorized by the factory (its current owner or an enabled
- *      router) can execute calls on any account created by this factory.
+ *      any enabled router can execute calls on any account created by this
+ *      factory.
  *      The factory also maintains a vetted/enabled router map to support
- *      experimental routers alongside the main owner.
+ *      experimental routers alongside the primary router.
  */
 contract RemoteAccountFactory is IRemoteAccountFactory {
     // Store the principal details of this factory purely for reference

--- a/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountFactory.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountFactory.sol
@@ -71,6 +71,20 @@ contract RemoteAccountFactory is IRemoteAccountFactory {
     address public vettingAuthority;
     address private _pendingVettingAuthority;
 
+    modifier onlyAuthorizedRouter() {
+        if (!isAuthorizedRouter(msg.sender)) {
+            revert UnauthorizedCaller(msg.sender);
+        }
+        _;
+    }
+
+    modifier onlyVettingAuthority() {
+        if (msg.sender != vettingAuthority) {
+            revert UnauthorizedCaller(msg.sender);
+        }
+        _;
+    }
+
     /**
      * @param factoryPrincipalCaip2_ The caip2 of the principal for this RemoteAccountFactory
      * @param factoryPrincipalAccount_ The address of the principal for this RemoteAccountFactory
@@ -272,10 +286,7 @@ contract RemoteAccountFactory is IRemoteAccountFactory {
      * @dev Only the vetting authority can vet routers. Vetting does not authorize the router.
      * @param router The router address to vet
      */
-    function vetRouter(address router) public {
-        if (msg.sender != vettingAuthority) {
-            revert UnauthorizedCaller(msg.sender);
-        }
+    function vetRouter(address router) public onlyVettingAuthority {
         if (_routerStatus[router] == RouterStatus.Unknown) {
             _routerStatus[router] = RouterStatus.Vetted;
             emit RouterVetted(router);
@@ -288,11 +299,10 @@ contract RemoteAccountFactory is IRemoteAccountFactory {
      *      Reverts if the factory is already initialized (any router authorized).
      * @param router The router address to vet and authorize
      */
-    function vetInitialRouter(address router) external {
+    function vetInitialRouter(address router) external onlyVettingAuthority {
         if (numberOfAuthorizedRouters > 0) {
             revert UnauthorizedCaller(msg.sender);
         }
-        // This will check that the caller is authorized.
         vetRouter(router);
         _authorizeRouter(router);
     }
@@ -302,10 +312,7 @@ contract RemoteAccountFactory is IRemoteAccountFactory {
      * @dev Only an authorized router can authorize other routers. Router must be vetted first.
      * @param router The router address to authorize
      */
-    function authorizeRouter(address router) external override {
-        if (!isAuthorizedRouter(msg.sender)) {
-            revert UnauthorizedCaller(msg.sender);
-        }
+    function authorizeRouter(address router) external override onlyAuthorizedRouter {
         _authorizeRouter(router);
     }
 
@@ -332,8 +339,8 @@ contract RemoteAccountFactory is IRemoteAccountFactory {
      * @dev Only an authorized router different from the sender can deauthorize
      * @param router The router address to deauthorize
      */
-    function deauthorizeRouter(address router) external override {
-        if (router == msg.sender || !isAuthorizedRouter(msg.sender)) {
+    function deauthorizeRouter(address router) external override onlyAuthorizedRouter {
+        if (router == msg.sender) {
             revert UnauthorizedCaller(msg.sender);
         }
         RouterStatus status = _routerStatus[router];
@@ -351,10 +358,7 @@ contract RemoteAccountFactory is IRemoteAccountFactory {
      * @dev Only the vetting authority can unvet. Router must be deauthorized first.
      * @param router The router address to unvet
      */
-    function unvetRouter(address router) external {
-        if (msg.sender != vettingAuthority) {
-            revert UnauthorizedCaller(msg.sender);
-        }
+    function unvetRouter(address router) external onlyVettingAuthority {
         RouterStatus status = _routerStatus[router];
         if (status != RouterStatus.Vetted) {
             if (status == RouterStatus.Unknown) {
@@ -373,10 +377,9 @@ contract RemoteAccountFactory is IRemoteAccountFactory {
      *      become the new vetting authority.
      * @param newVettingAuthority The address of the new vetting authority
      */
-    function proposeVettingAuthorityTransfer(address newVettingAuthority) external {
-        if (msg.sender != vettingAuthority) {
-            revert UnauthorizedCaller(msg.sender);
-        }
+    function proposeVettingAuthorityTransfer(
+        address newVettingAuthority
+    ) external onlyVettingAuthority {
         _pendingVettingAuthority = newVettingAuthority;
         emit VettingAuthorityTransferProposed(msg.sender, newVettingAuthority);
     }
@@ -387,10 +390,9 @@ contract RemoteAccountFactory is IRemoteAccountFactory {
      *      previously proposed address.
      * @param newVettingAuthority The address of the new vetting authority (must be proposed first)
      */
-    function confirmVettingAuthorityTransfer(address newVettingAuthority) external override {
-        if (!isAuthorizedRouter(msg.sender)) {
-            revert UnauthorizedCaller(msg.sender);
-        }
+    function confirmVettingAuthorityTransfer(
+        address newVettingAuthority
+    ) external override onlyAuthorizedRouter {
         if (newVettingAuthority != _pendingVettingAuthority || newVettingAuthority == address(0)) {
             revert InvalidVettingAuthority(newVettingAuthority, _pendingVettingAuthority);
         }

--- a/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountFactory.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountFactory.sol
@@ -72,9 +72,7 @@ contract RemoteAccountFactory is IRemoteAccountFactory {
     address private _pendingVettingAuthority;
 
     modifier onlyAuthorizedRouter() {
-        if (!isAuthorizedRouter(msg.sender)) {
-            revert UnauthorizedCaller(msg.sender);
-        }
+        checkAuthorizedRouter(msg.sender);
         _;
     }
 
@@ -269,6 +267,17 @@ contract RemoteAccountFactory is IRemoteAccountFactory {
      */
     function isAuthorizedRouter(address caller) public view override returns (bool) {
         return _routerStatus[caller] == RouterStatus.Authorized;
+    }
+
+    /**
+     * @notice Check that a caller is an authorized router
+     * @dev Reverts if the caller is not an authorized router.
+     * @param caller The address to check
+     */
+    function checkAuthorizedRouter(address caller) public view override {
+        if (!isAuthorizedRouter(caller)) {
+            revert UnauthorizedCaller(caller);
+        }
     }
 
     /**

--- a/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountFactory.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountFactory.sol
@@ -233,6 +233,9 @@ contract RemoteAccountFactory is Ownable, IRemoteAccountFactory {
      * @notice Transfer factory ownership to a new owner
      * @dev Overrides Ownable.transferOwnership to require the new owner is vetted.
      *      Setting a new owner automatically enables it.
+     *      XXX The previous owner stays enabled to support concurrent multi-router
+     *      operation. The caller must explicitly disableRouter the old owner via
+     *      GMP if it should no longer be authorized.
      * @param newOwner The address of the new owner (must be vetted)
      */
     function transferOwnership(address newOwner) public override onlyOwner {

--- a/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountFactory.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountFactory.sol
@@ -31,6 +31,8 @@ contract RemoteAccountFactory is IRemoteAccountFactory {
     /// @notice The pre-deployed RemoteAccount implementation that all clones delegate to
     address public immutable implementation;
 
+    uint256 public numberOfAuthorizedRouters;
+
     mapping(address => RouterStatus) private _routerStatus;
 
     /// @notice The address authorized to vet and revoke routers.
@@ -48,30 +50,26 @@ contract RemoteAccountFactory is IRemoteAccountFactory {
      * @param factoryPrincipalAccount_ The address of the principal for this RemoteAccountFactory
      * @param implementation_ The address of the pre-deployed RemoteAccount implementation contract.
      *        This implementation must have its initializers disabled to ensure it is inert.
-     * @param initialRouter The initial router to enable
-     * @param vettingAuthority_ The address authorized to vet and revoke routers
+     * @param initialVettingAuthority_ The initial address authorized to vet and revoke routers
      */
     constructor(
         string memory factoryPrincipalCaip2_,
         string memory factoryPrincipalAccount_,
         address implementation_,
-        address initialRouter,
-        address vettingAuthority_
+        address initialVettingAuthority_
     ) {
         factoryPrincipalCaip2 = factoryPrincipalCaip2_;
         factoryPrincipalAccount = factoryPrincipalAccount_;
         _principalSalt = keccak256(bytes(factoryPrincipalAccount_)); // _getSalt(factoryPrincipalAccount_);
         implementation = implementation_;
-        _routerStatus[initialRouter] = RouterStatus.Enabled;
-        emit RouterVetted(initialRouter);
-        emit RouterEnabled(initialRouter);
-        if (vettingAuthority_ == address(0)) {
-            vettingAuthority = msg.sender;
-        } else {
-            vettingAuthority = vettingAuthority_;
-        }
 
-        // The initial router must be vetted and enabled by the constructor since there is no owner to call vetRouter or enableRouter.
+        if (initialVettingAuthority_ == address(0)) {
+            // The "expected" address in the error is somewhat subjective, but
+            // it should be clear that the zero address is not valid.
+            revert InvalidVettingAuthority(initialVettingAuthority_, msg.sender);
+        }
+        vettingAuthority = initialVettingAuthority_;
+
         try RemoteAccount(payable(implementation_)).factory() returns (address implFactory) {
             if (implFactory != address(0)) {
                 revert('Implementation must be an inert RemoteAccount contract');
@@ -243,7 +241,7 @@ contract RemoteAccountFactory is IRemoteAccountFactory {
      * @dev Only the vetting authority can vet routers. Vetting does not enable the router.
      * @param router The router address to vet
      */
-    function vetRouter(address router) external {
+    function vetRouter(address router) public {
         if (msg.sender != vettingAuthority) {
             revert UnauthorizedCaller(msg.sender);
         }
@@ -251,6 +249,21 @@ contract RemoteAccountFactory is IRemoteAccountFactory {
             _routerStatus[router] = RouterStatus.Vetted;
             emit RouterVetted(router);
         }
+    }
+
+    /**
+     * @notice Vet and enable the initial router
+     * @dev Only the vetting authority can authorize the initial router.
+     *      Reverts if already initialized (any router authorized).
+     * @param router The router address to vet and enable
+     */
+    function vetInitialRouter(address router) external {
+        if (numberOfAuthorizedRouters > 0) {
+            revert UnauthorizedCaller(msg.sender);
+        }
+        // This will check that the caller is authorized.
+        vetRouter(router);
+        _enableRouter(router);
     }
 
     /**
@@ -262,6 +275,15 @@ contract RemoteAccountFactory is IRemoteAccountFactory {
         if (!isAuthorizedRouter(msg.sender)) {
             revert UnauthorizedCaller(msg.sender);
         }
+        _enableRouter(router);
+    }
+
+    /**
+     * @notice Enable a vetted router to operate on remote accounts
+     * @dev The internal caller must ensure the caller is authorized. Router must be vetted first.
+     * @param router The router address to enable
+     */
+    function _enableRouter(address router) internal {
         if (_routerStatus[router] != RouterStatus.Vetted) {
             if (_routerStatus[router] == RouterStatus.Enabled) {
                 return;
@@ -269,7 +291,8 @@ contract RemoteAccountFactory is IRemoteAccountFactory {
             revert RouterNotVetted(router);
         }
         _routerStatus[router] = RouterStatus.Enabled;
-        emit RouterEnabled(router);
+        numberOfAuthorizedRouters += 1;
+        emit RouterEnabled(router, numberOfAuthorizedRouters);
     }
 
     /**
@@ -288,7 +311,8 @@ contract RemoteAccountFactory is IRemoteAccountFactory {
             revert RouterNotEnabled(router);
         }
         _routerStatus[router] = RouterStatus.Vetted;
-        emit RouterDisabled(router);
+        numberOfAuthorizedRouters -= 1;
+        emit RouterDisabled(router, numberOfAuthorizedRouters);
     }
 
     /**

--- a/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountFactory.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountFactory.sol
@@ -102,7 +102,7 @@ contract RemoteAccountFactory is IRemoteAccountFactory {
         } catch {
             revert('Implementation must be a RemoteAccount contract');
         }
-        try RemoteAccount(payable(implementation_)).initialize(address(0)) {
+        try RemoteAccount(payable(implementation_)).initialize(address(0), '') {
             revert('Implementation must be an inert RemoteAccount contract');
         } catch {
             // Expected to revert because the implementation should have initializers disabled
@@ -237,7 +237,7 @@ contract RemoteAccountFactory is IRemoteAccountFactory {
 
         // Initialize the clone with this factory's address.
         // The clone immutably delegates authorization to this factory.
-        RemoteAccount(payable(newAccountAddress)).initialize(address(this));
+        RemoteAccount(payable(newAccountAddress)).initialize(address(this), principalAccount);
 
         emit RemoteAccountCreated(newAccountAddress, principalAccount);
     }

--- a/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountFactory.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountFactory.sol
@@ -115,7 +115,7 @@ contract RemoteAccountFactory is IRemoteAccountFactory {
         } catch {
             revert InvalidImplementation(implementation_);
         }
-        try RemoteAccount(payable(implementation_)).initialize(address(0), '') {
+        try RemoteAccount(payable(implementation_)).initialize(address(0)) {
             revert InvalidImplementation(implementation_);
         } catch {
             // Expected to revert because the implementation should have initializers disabled
@@ -254,7 +254,7 @@ contract RemoteAccountFactory is IRemoteAccountFactory {
 
         // Initialize the clone with this factory's address.
         // The clone immutably delegates authorization to this factory.
-        RemoteAccount(payable(newAccountAddress)).initialize(address(this), principalAccount);
+        RemoteAccount(payable(newAccountAddress)).initialize(address(this));
 
         emit RemoteAccountCreated(newAccountAddress, principalAccount);
     }

--- a/packages/axelar-local-dev-cosmos/src/contracts/design.md
+++ b/packages/axelar-local-dev-cosmos/src/contracts/design.md
@@ -123,15 +123,16 @@ graph TB
     subgraph RemoteAccountAxelarRouter
         START@{shape: start}
         _execute["_execute<br/>override AxelarExecutable"]
-        VALIDATE@{shape: text, label: "Axelar inbound validation"}
-        DECODE{decode and dispatch}
+        VALIDATE@{shape: text, label: "validate source and<br>decoded payload"}
+        DISPATCH@{shape: text, label: "self-call instruction<br>processor"}
+        OOG@{shape: text, label: "revert<br>SubcallOutOfGas()"}
         processProvideRemoteAccountInstruction["processProvideRemoteAccountInstruction<br>override IRemoteAccountRouter"]
         processProvideRemoteAccountInstruction_self@{shape: comment, label: "require self-call"}
         processRemoteAccountExecuteInstruction["processRemoteAccountExecuteInstruction<br>override IRemoteAccountRouter"]
         processRemoteAccountExecuteInstruction_self@{shape: comment, label: "require self-call"}
         adminInstructions["processEnableRouterInstruction |<br>processDisableRouterInstruction |<br>processConfirmVettingAuthorityInstruction"]
         adminInstructions_self@{shape: comment, label: "require self-call"}
-        VERIFY_PRINCIPAL@{shape: text, label: "verify factory<br>principal"}
+        VERIFY_FACTORY@{shape: text, label: "verify factory address<br>and principal"}
         DEP@{shape: text, label: "Permit2 Integration"}
         PROV@{shape: text, label: "account creation/<br>verification"}
         MULTI@{shape: text, label: "account use"}
@@ -139,6 +140,7 @@ graph TB
         subgraph state
             factory@{shape: stored-data, label: "factory: IRemoteAccountFactory<br>override IRemoteAccountRouter"}
             permit2@{shape: stored-data, label: "permit2: IPermit2<br>override IRemoteAccountRouter"}
+            axelarSourceChain@{shape: stored-data, label: "axelarSourceChain: string"}
             axelarSourceChainHash@{shape: stored-data, label: "axelarSourceChainHash: bytes32"}
         end
     end
@@ -152,26 +154,27 @@ graph TB
     %% operation
     START --> _execute
     _execute -->|"[1]"| VALIDATE
-    _execute -->|"[2]"| DECODE
-    DECODE -.-> processProvideRemoteAccountInstruction
-    DECODE -.-> processRemoteAccountExecuteInstruction
-    DECODE -.-> adminInstructions
+    _execute -->|"[2]"| DISPATCH
+    _execute -->|"[3] gas heuristics"| OOG
+    DISPATCH -.-> processProvideRemoteAccountInstruction
+    DISPATCH -.-> processRemoteAccountExecuteInstruction
+    DISPATCH -.-> adminInstructions
     processProvideRemoteAccountInstruction --> processProvideRemoteAccountInstruction_self
-    processProvideRemoteAccountInstruction -->|"[1]"| VERIFY_PRINCIPAL
+    processProvideRemoteAccountInstruction -->|"[1]"| VERIFY_FACTORY
     processProvideRemoteAccountInstruction -.->|"[2] effect deposit"| DEP
     processProvideRemoteAccountInstruction -->|"[3] provide account"| PROV
     processRemoteAccountExecuteInstruction --> processRemoteAccountExecuteInstruction_self
     processRemoteAccountExecuteInstruction -->|"[1] provide account"| PROV
     processRemoteAccountExecuteInstruction -->|"[2] send calls"| MULTI
     adminInstructions --> adminInstructions_self
-    adminInstructions -->|"[1]"| VERIFY_PRINCIPAL
+    adminInstructions -->|"[1]"| VERIFY_FACTORY
     adminInstructions -->|"[2]"| ADMIN_CALL
-    _execute -->|"[3] emit"| OperationResult
+    _execute -->|"[4] else emit"| OperationResult
 
     %% state/dependency access
     VALIDATE -->|checks| axelarSourceChainHash
     DEP -->|call<br>permitWitnessTransferFrom| permit2
-    VERIFY_PRINCIPAL -->|call verifyFactoryPrincipalAccount| factory
+    VERIFY_FACTORY -->|call verifyFactoryPrincipalAccount| factory
     PROV -->|call provideRemoteAccount| factory
     MULTI --> |call executeCalls| RAn
     ADMIN_CALL -->|call| factory
@@ -185,13 +188,14 @@ graph TB
 
 **Key Components**:
 
-- **\_execute**: Validates source chain, decodes the instruction selector + payload, dispatches to processor
+- **\_execute**: Validates source chain, selector, and common decoded payload arguments before dispatching
 - **processProvideRemoteAccountInstruction**: Atomically redeems an optional deposit permit and provisions/verifies a RemoteAccount via the factory
 - **processRemoteAccountExecuteInstruction**: Atomically provisions/verifies a RemoteAccount and executes its multicall batch
-- **processEnableRouterInstruction / processDisableRouterInstruction / processConfirmVettingAuthorityInstruction**: Admin instructions that verify the factory principal, then call the corresponding factory method (requires factory principal)
+- **processEnableRouterInstruction / processDisableRouterInstruction / processConfirmVettingAuthorityInstruction**: Admin instructions that verify the factory principal, then call the corresponding factory method
 - **Permit2 Integration**: Transfers tokens to RemoteAccount via Permit2 signature-based transfers
 - **account creation/verification**: Creates or verifies RemoteAccount via factory
 - **account use**: Instructs RemoteAccount to execute arbitrary multicalls
+- **OperationResult / SubcallOutOfGas**: Processor-level success and failure produce `OperationResult`; selected out-of-gas cases revert with `SubcallOutOfGas`
 
 ---
 
@@ -207,16 +211,22 @@ graph TB
     end
     subgraph IRemoteAccount
         IRemoteAccount_executeCalls[executeCalls]
+        %% events
+        Received@{shape: flag}
+        ContractCallSuccess@{shape: flag}
     end
 
     subgraph RemoteAccount
         START@{shape: start}
         CTOR[constructor]
         initialize
+        receive
         executeCalls
         AUTH_CHECK@{shape: text, label: "check factory.isAuthorizedRouter"}
+        CALL["process call<br>instruction"]
         subgraph state
             factory_ref@{shape: stored-data, label: "factory: address"}
+            principalAccount_ref@{shape: stored-data, label: "principalAccount: string"}
         end
     end
 
@@ -231,12 +241,18 @@ graph TB
     %% operation
     START --> CTOR
     START --> initialize
+    START --> receive
     START --> executeCalls
     CTOR -->|calls| _disableInitializers
     initialize -->|modifier| initializer
     initialize -->|sets| factory_ref
+    initialize -->|sets| principalAccount_ref
     executeCalls -->|"[1]"| AUTH_CHECK
-    executeCalls -.->|"[2] loops & calls"| EXTERNAL
+    executeCalls -->|"[2] value > 0"| Received
+    executeCalls -->|"[3] loops"| CALL
+    CALL -.->|"[1] calls"| EXTERNAL
+    CALL -.->|"[2] emits"| ContractCallSuccess
+    receive -->|"emits"| Received
 
     %% state/dependency access
     AUTH_CHECK -->|call isAuthorizedRouter| FACTORY
@@ -249,8 +265,9 @@ graph TB
 
 **Key Components**:
 
-- **initialize**: One-time factory reference initialization for clone instances
-- **executeCalls**: Checks authorization via `factory.isAuthorizedRouter(msg.sender)`, then atomically executes array of contract calls
+- **initialize**: One-time factory and `principalAccount` initialization for clone instances
+- **receive**: Accepts native token transfers and emits `Received`
+- **executeCalls**: Checks authorization via `factory.isAuthorizedRouter(msg.sender)`, then atomically executes array of contract calls with per-call reporting
 
 ## C4 Level 3: Component Diagrams - RemoteAccountFactory
 
@@ -461,7 +478,7 @@ graph TB
 **Key Components (Remote Account Operations)**:
 
 - **provideRemoteAccount**: Creates or verifies a remote account at the expected address derived from the principal
-- **verifyRemoteAccount**: Multi-layer verification of existing accounts (code, principal)
+- **verifyRemoteAccount**: Verification of existing accounts by deterministic address derivation and code existence
 - **verifyFactoryPrincipalAccount**: Validates the factory principal account string
 - **\_verifyRemoteAccountAddress**: Enforces principal-to-address derivation before creation/verification
 - **\_getRemoteAccountAddress**: Rejects the factory principal account (prevents treating factory as a remote account)
@@ -496,6 +513,7 @@ sequenceDiagram
     D->>RAF: deploy(caip2, principalAccount,<br>implementation, vettingAuthority)
     RAF->>RAF: store immutables
     RAF->>RA_IMPL: factory() — verify implementation is inert
+    RAF->>RA_IMPL: initialize(address(0), '') — verify initializers disabled
 
     Note over D: Step 3: Deploy router
     D->>R: deploy(gateway, sourceChain,<br>factory, permit2)
@@ -530,7 +548,7 @@ sequenceDiagram
     PM->>AXL: send ProvideRemoteAccountInstruction |<br>RemoteAccountExecuteInstruction |<br>EnableRouterInstruction |<br>DisableRouterInstruction |<br>ConfirmVettingAuthorityInstruction
     AXL->>PR: _execute(sourceChain,<br>sourceAddress, payload)
 
-    PR->>PR: validate source chain
+    PR->>PR: validate source chain<br>and payload shape
 
     critical
         alt processProvideRemoteAccountInstruction
@@ -583,7 +601,9 @@ sequenceDiagram
         end
     option [success]
         PR->>PR: emit OperationResult(id, true, '')
-    option [failure]
+    option [failure / Out-of-gas heuristics]
+        PR->>PR: revert SubcallOutOfGas()
+    option [other failure]
         PR->>PR: emit OperationResult(id, false, reason)
     end
 ```
@@ -609,7 +629,7 @@ sequenceDiagram
     - For `processConfirmVettingAuthorityInstruction`:
         1. RemoteAccountAxelarRouter verifies the factory principal matches the source address
         2. RemoteAccountAxelarRouter confirms the pending vetting authority transfer on the factory
-4. RemoteAccountAxelarRouter emits an event describing success or failure
+4. RemoteAccountAxelarRouter emits `OperationResult` for instruction success or failure, but hard-reverts for detected `SubcallOutOfGas`
 
 ## Ownership and Security Model
 
@@ -679,6 +699,7 @@ sequenceDiagram
     Note over PM,RA: Initial deployment
     EVM_DEPLOYER->>IMP: deploy
     EVM_DEPLOYER->>RAF: deploy(principal, impl,<br>vettingAuthority=VA)
+    RAF->>IMP: factory() / initialize(address(0), '') checks
     EVM_DEPLOYER->>ROUTER1: deploy(gateway, sourceChain, factory=RAF, permit2)
     VA->>RAF: vetInitialRouter(ROUTER1)
 

--- a/packages/axelar-local-dev-cosmos/src/contracts/design.md
+++ b/packages/axelar-local-dev-cosmos/src/contracts/design.md
@@ -388,8 +388,11 @@ graph TB
         isAuthorizedRouter["isAuthorizedRouter<br>override IRemoteAccountFactory"]
         getRouterStatus
 
-        subgraph "EVM-sourced (vetting authority)"
-            CHECK_VA@{shape: text, label: "check msg.sender ==<br>vettingAuthority"}
+        %% modifiers
+        onlyVettingAuthority@{shape: odd, label: "onlyVettingAuthority<br>modifier"}
+        onlyAuthorizedRouter@{shape: odd, label: "onlyAuthorizedRouter<br>modifier"}
+
+        subgraph "EVM-sourced<br>(vetting authority)"
             vetInitialRouter
             vetRouter
             unvetRouter
@@ -398,8 +401,7 @@ graph TB
 
         _authorizeRouter["_authorizeRouter (internal)"]
 
-        subgraph "Agoric-sourced (authorized router)"
-            CHECK_ROUTER@{shape: text, label: "check isAuthorizedRouter<br>(msg.sender)"}
+        subgraph "Agoric controller-sourced<br>(authorized router)"
             authorizeRouter["authorizeRouter<br>override IRemoteAccountFactory"]
             deauthorizeRouter["deauthorizeRouter<br>override IRemoteAccountFactory"]
             confirmVettingAuthorityTransfer["confirmVettingAuthorityTransfer<br>override IRemoteAccountFactory"]
@@ -431,46 +433,48 @@ graph TB
     getRouterStatus -->|reads| _routerStatus
 
     %% EVM-sourced operations (vetting authority)
+    vetInitialRouter -->|"modifier"| onlyVettingAuthority
     vetInitialRouter -->|"[1] guard"| numberOfAuthorizedRouters
     vetInitialRouter -->|"[2] calls"| vetRouter
     vetInitialRouter -->|"[3] calls"| _authorizeRouter
 
-    vetRouter -->|"[1]"| CHECK_VA
-    vetRouter -->|"[2] updates"| _routerStatus
+    vetRouter -->|"modifier"| onlyVettingAuthority
+    vetRouter -->|"[1] updates"| _routerStatus
     vetRouter -->|emit| RouterVetted
 
-    unvetRouter -->|"[1]"| CHECK_VA
-    unvetRouter -->|"[2] updates"| _routerStatus
+    unvetRouter -->|"modifier"| onlyVettingAuthority
+    unvetRouter -->|"[1] updates"| _routerStatus
     unvetRouter -->|emit| RouterUnvetted
 
-    proposeVettingAuthorityTransfer -->|"[1]"| CHECK_VA
-    proposeVettingAuthorityTransfer -->|"[2] updates"| _pendingVettingAuthority
+    proposeVettingAuthorityTransfer -->|"modifier"| onlyVettingAuthority
+    proposeVettingAuthorityTransfer -->|"[1] updates"| _pendingVettingAuthority
     proposeVettingAuthorityTransfer -->|emit| VettingAuthorityTransferProposed
 
-    CHECK_VA -->|checks| vettingAuthority
+    onlyVettingAuthority -->|checks| vettingAuthority
 
     %% Agoric-sourced operations (authorized router)
-    authorizeRouter -->|"[1]"| CHECK_ROUTER
-    authorizeRouter -->|"[2] calls"| _authorizeRouter
+    authorizeRouter -->|"modifier"| onlyAuthorizedRouter
+    authorizeRouter -->|"[1] calls"| _authorizeRouter
 
     _authorizeRouter -->|"[1] updates"| _routerStatus
     _authorizeRouter -->|"[2] increments"| numberOfAuthorizedRouters
     _authorizeRouter -->|emit| RouterAuthorized
 
-    deauthorizeRouter -->|"[1]"| CHECK_ROUTER
+    deauthorizeRouter -->|"modifier"| onlyAuthorizedRouter
+    deauthorizeRouter -->|"[1] not self-check"| deauthorizeRouter
     deauthorizeRouter -->|"[2] updates"| _routerStatus
     deauthorizeRouter -->|"[3] decrements"| numberOfAuthorizedRouters
     deauthorizeRouter -->|emit| RouterDeauthorized
 
-    confirmVettingAuthorityTransfer -->|"[1]"| CHECK_ROUTER
-    confirmVettingAuthorityTransfer -->|"[2] checks"| _pendingVettingAuthority
-    confirmVettingAuthorityTransfer -->|"[3] updates"| vettingAuthority
+    confirmVettingAuthorityTransfer -->|"modifier"| onlyAuthorizedRouter
+    confirmVettingAuthorityTransfer -->|"[1] checks"| _pendingVettingAuthority
+    confirmVettingAuthorityTransfer -->|"[2] updates"| vettingAuthority
     confirmVettingAuthorityTransfer -->|emit| VettingAuthorityTransferred
 
-    CHECK_ROUTER -->|calls| isAuthorizedRouter
+    onlyAuthorizedRouter -->|calls| isAuthorizedRouter
 
 
-    class isAuthorizedRouter,getRouterStatus,CHECK_VA,CHECK_ROUTER readonly
+    class isAuthorizedRouter,getRouterStatus,onlyVettingAuthority,onlyAuthorizedRouter readonly
     class vetInitialRouter,vetRouter,unvetRouter,proposeVettingAuthorityTransfer evm
     class authorizeRouter,deauthorizeRouter,confirmVettingAuthorityTransfer controller
     class _authorizeRouter internal
@@ -491,6 +495,8 @@ graph TB
 
 **Key Components (Router & Vetting Authority Administration)**:
 
+- **onlyVettingAuthority**: Shared modifier enforcing `msg.sender == vettingAuthority` for EVM-side administrative entrypoints
+- **onlyAuthorizedRouter**: Shared modifier enforcing `isAuthorizedRouter(msg.sender)` for Agoric-controlled administrative entrypoints
 - **vetInitialRouter**: Vets and authorizes the very first router (vetting authority only, no previous router). This initializes the factory.
 - **vetRouter**: Marks a router as vetted (vetting authority only)
 - **authorizeRouter**: Authorizes a vetted router (authorized router only)
@@ -783,8 +789,8 @@ graph TB
 - **RemoteAccountAxelarRouter `_execute`**: Validate `sourceChain` against immutable hash
 - **RemoteAccountAxelarRouter admin instructions**: Validate the source address as the factory principal (ensures only the portfolio manager can manage routers or redeem signed permits)
 - **RemoteAccountFactory `provideRemoteAccount`**: Validates remote account address derives from the principal account string
-- **RemoteAccountFactory `vetRouter`/`unvetRouter`**: Only the vetting authority can call these
-- **RemoteAccountFactory `authorizeRouter`/`deauthorizeRouter`**: Only an already-authorized router can call these (preventing unauthorized routers from self-authorizing)
+- **RemoteAccountFactory `onlyVettingAuthority` modifier**: Centralizes `msg.sender == vettingAuthority` enforcement for vetting-authority entrypoints
+- **RemoteAccountFactory `onlyAuthorizedRouter` modifier**: Centralizes `isAuthorizedRouter(msg.sender)` enforcement for router-controlled entrypoints, preventing unauthorized routers from self-authorizing
 - **RemoteAccountFactory `deauthorizeRouter`**: A router cannot deauthorize itself
 - **RemoteAccount `executeCalls`**: Validates that the caller is an authorized router via `factory.isAuthorizedRouter(msg.sender)`
 

--- a/packages/axelar-local-dev-cosmos/src/contracts/design.md
+++ b/packages/axelar-local-dev-cosmos/src/contracts/design.md
@@ -363,6 +363,11 @@ graph TB
 
 ```mermaid
 graph TB
+    classDef evm fill:#ffe6e6,stroke:#c66,color:#111
+    classDef controller fill:#e6f4ff,stroke:#4b88a2,color:#111
+    classDef internal fill:#fff0e6,stroke:#c99246,color:#111
+    classDef readonly fill:#eef6e8,stroke:#6f8a63,color:#111
+
     subgraph IRemoteAccountFactory
         IRemoteAccountFactory_isAuthorizedRouter[isAuthorizedRouter]
         IRemoteAccountFactory_authorizeRouter[authorizeRouter]
@@ -464,15 +469,14 @@ graph TB
 
     CHECK_ROUTER -->|calls| isAuthorizedRouter
 
-    style isAuthorizedRouter fill:#ffe6e6
-    style vetInitialRouter fill:#ffe6e6
-    style vetRouter fill:#ffe6e6
-    style authorizeRouter fill:#ffe6e6
-    style _authorizeRouter fill:#fff0e6
-    style deauthorizeRouter fill:#ffe6e6
-    style unvetRouter fill:#ffe6e6
-    style proposeVettingAuthorityTransfer fill:#ffe6e6
-    style confirmVettingAuthorityTransfer fill:#ffe6e6
+
+    class isAuthorizedRouter,getRouterStatus,CHECK_VA,CHECK_ROUTER readonly
+    class vetInitialRouter,vetRouter,unvetRouter,proposeVettingAuthorityTransfer evm
+    class authorizeRouter,deauthorizeRouter,confirmVettingAuthorityTransfer controller
+    class _authorizeRouter internal
+    class LEGEND_EVM evm
+    class LEGEND_CONTROLLER controller
+    class LEGEND_INTERNAL internal
 ```
 
 **Key Components (Remote Account Operations)**:
@@ -494,6 +498,107 @@ graph TB
 - **unvetRouter**: Unvets a vetted router (vetting authority only)
 - **proposeVettingAuthorityTransfer**: Proposes a new vetting authority (current vetting authority only)
 - **confirmVettingAuthorityTransfer**: Confirms the pending vetting authority transfer (authorized router only)
+
+## Router State Machine
+
+```mermaid
+stateDiagram-v2
+    classDef evm fill:#ffe6e6,stroke:#c66,color:#111
+    classDef controller fill:#e6f4ff,stroke:#4b88a2,color:#111
+    classDef stable fill:#eef6e8,stroke:#6f8a63,color:#111
+
+    [*] --> Unknown
+
+    state "EVM action<br/>vetRouter(router)" as EVMVet
+    state "EVM action<br/>vetInitialRouter(router)" as EVMBootstrap
+    state "Controller action<br/>authorizeRouter(router)" as ControllerAuthorize
+    state "Controller action<br/>deauthorizeRouter(router)" as ControllerDeauthorize
+    state "EVM action<br/>unvetRouter(router)" as EVMUnvet
+
+    Unknown --> EVMVet
+    EVMVet --> Vetted: RouterVetted
+
+    Unknown --> EVMBootstrap
+    EVMBootstrap --> Authorized: bootstrap = vet + authorize
+
+    Vetted --> ControllerAuthorize
+    ControllerAuthorize --> Authorized: RouterAuthorized
+
+    Authorized --> ControllerDeauthorize
+    ControllerDeauthorize --> Vetted: RouterDeauthorized
+
+    Vetted --> EVMUnvet
+    EVMUnvet --> Unknown: RouterUnvetted
+
+    class Unknown,Vetted,Authorized stable
+    class EVMVet,EVMBootstrap,EVMUnvet evm
+    class ControllerAuthorize,ControllerDeauthorize controller
+
+    note right of Unknown
+        Router is neither vetted nor authorized.
+        isAuthorizedRouter(router) == false
+    end note
+
+    note right of Vetted
+        Router code is approved but cannot operate accounts.
+        isAuthorizedRouter(router) == false
+    end note
+
+    note right of Authorized
+        Router is vetted and operational.
+        isAuthorizedRouter(router) == true
+    end note
+```
+
+**State Transition Notes**:
+
+- `vetInitialRouter` is a bootstrap-only shortcut from `Unknown` to `Authorized`; internally it performs `vetRouter` then `_authorizeRouter`.
+- `authorizeRouter` only changes state when the router is already `Vetted`; calling it for an already `Authorized` router is idempotent.
+- `deauthorizeRouter` only changes state when the router is currently `Authorized`; calling it for `Vetted` or `Unknown` is a no-op.
+- `unvetRouter` only changes state when the router is currently `Vetted`; calling it for `Unknown` is a no-op, and calling it for `Authorized` reverts.
+
+## Vetting Authority Transfer State Machine
+
+```mermaid
+stateDiagram-v2
+    classDef evm fill:#ffe6e6,stroke:#c66,color:#111
+    classDef controller fill:#e6f4ff,stroke:#4b88a2,color:#111
+    classDef stable fill:#eef6e8,stroke:#6f8a63,color:#111
+
+    [*] --> NoPendingTransfer
+
+    state "No pending transfer<br/>\_pendingVettingAuthority = address(0)<br>vettingAuthority = initialAuthority\_ / newAuthority" as NoPendingTransfer
+    state "EVM action<br/>proposeVettingAuthorityTransfer(newAuthority)" as EVMPropose
+    state "Pending transfer<br/>_pendingVettingAuthority = newAuthority" as PendingTransfer
+    state "Controller action<br/>confirmVettingAuthorityTransfer(newAuthority)" as ControllerConfirm
+
+    NoPendingTransfer --> EVMPropose
+    EVMPropose --> PendingTransfer: VettingAuthorityTransferProposed
+
+    PendingTransfer --> ControllerConfirm
+    ControllerConfirm --> NoPendingTransfer: VettingAuthorityTransferred
+
+    class NoPendingTransfer,PendingTransfer stable
+    class EVMPropose evm
+    class ControllerConfirm controller
+
+    note right of NoPendingTransfer
+        vettingAuthority is active.
+        No transfer is awaiting confirmation.
+    end note
+
+    note right of PendingTransfer
+        Current vettingAuthority is unchanged.
+        Only the exact pending address can be confirmed.
+    end note
+```
+
+**Transfer Notes**:
+
+- The transfer is two-step by design: the current vetting authority proposes, and an already-authorized router confirms.
+- Proposal alone does not change `vettingAuthority`; it only sets `_pendingVettingAuthority`.
+- Confirmation must name the exact pending address and cannot confirm the zero address.
+- Once confirmed, the pending value is cleared, so any later transfer requires a fresh proposal.
 
 ## Data Flow: Factory deployment and initial router setup
 

--- a/packages/axelar-local-dev-cosmos/src/contracts/design.md
+++ b/packages/axelar-local-dev-cosmos/src/contracts/design.md
@@ -226,7 +226,6 @@ graph TB
         CALL["process call<br>instruction"]
         subgraph state
             factory_ref@{shape: stored-data, label: "factory: address"}
-            principalAccount_ref@{shape: stored-data, label: "principalAccount: string"}
         end
     end
 
@@ -246,7 +245,6 @@ graph TB
     CTOR -->|calls| _disableInitializers
     initialize -->|modifier| initializer
     initialize -->|sets| factory_ref
-    initialize -->|sets| principalAccount_ref
     executeCalls -->|"[1]"| AUTH_CHECK
     executeCalls -->|"[2] value > 0"| Received
     executeCalls -->|"[3] loops"| CALL
@@ -265,7 +263,7 @@ graph TB
 
 **Key Components**:
 
-- **initialize**: One-time factory and `principalAccount` initialization for clone instances
+- **initialize**: One-time factory initialization for clone instances
 - **receive**: Accepts native token transfers and emits `Received`
 - **executeCalls**: Calls `factory.checkAuthorizedRouter(msg.sender)`, then atomically executes array of contract calls with per-call reporting
 
@@ -343,7 +341,7 @@ graph TB
 
     _createRemoteAccount -->|calls| cloneDeterministic
     cloneDeterministic -->|"CREATE2"| RAn
-    _createRemoteAccount -->|"initialize(factory, principalAccount)"| RAn
+    _createRemoteAccount -->|"initialize(factory)"| RAn
     _createRemoteAccount -->|"emit"| RemoteAccountCreated
 
     getRemoteAccountAddress -->|calls| _getRemoteAccountAddress
@@ -682,7 +680,7 @@ sequenceDiagram
                 RAF->>RAF: verify address
             else
                 RAF->>RA: cloneDeterministic
-                RAF->>RA: initialize(factory, principalAccount)
+                RAF->>RA: initialize(factory)
             end
         else processRemoteAccountExecuteInstruction
             Note over PR,RA: provide account
@@ -691,7 +689,7 @@ sequenceDiagram
                 RAF->>RAF: verify address
             else
                 RAF->>RA: cloneDeterministic
-                RAF->>RA: initialize(factory, principalAccount)
+                RAF->>RA: initialize(factory)
             end
 
             Note over PR,RA: make calls

--- a/packages/axelar-local-dev-cosmos/src/contracts/design.md
+++ b/packages/axelar-local-dev-cosmos/src/contracts/design.md
@@ -65,22 +65,27 @@ graph TB
         PROTO[DeFi Protocols]
     end
 
+    VA[Vetting Authority<br/>EVM multisig]
+
     YMAX --> AXL
     LCA1 --> AXL
     LCA2 --> AXL
     LCAn --> AXL
     AXL -->|_execute| PR
     PR -->|provideRemoteAccount| RAF
+    PR -->|"enableRouter |<br>disableRouter |<br>confirmVettingAuthorityTransfer"| RAF
     RAF ==>|creates| RA1
     RAF ==>|creates| RA2
     RAF ==>|creates| RAn
     RA1 -.->|delegates to| IMP
     RA2 -.->|delegates to| IMP
     RAn -.->|delegates to| IMP
-    PR -->|"executeCalls |<br>transferOwnership"| RA1
-    PR -->|"executeCalls |<br>transferOwnership"| RA2
-    PR -->|"executeCalls |<br>transferOwnership"| RAn
+    PR -->|executeCalls| RA1
+    PR -->|executeCalls| RA2
+    PR -->|executeCalls| RAn
     PR -.->|permitWitnessTransferFrom| P2
+    VA -->|"vetRouter |<br>revokeRouter |<br>proposeVettingAuthorityTransfer"| RAF
+    IMP -->|checks caller| RAF
     IMP -->|call| PROTO
 
     style PR fill:#ffcccc
@@ -105,21 +110,12 @@ graph TB
     subgraph AxelarExecutable
         AxelarExecutable__execute["_execute<br>(message handler)"]
     end
-    subgraph ImmutableOwnable
-        %% modifiers
-        onlyOwner@{shape: odd}
-        %% state
-        owner@{shape: stored-data, label: "owner: address"}
-    end
     subgraph IRemoteAccountRouter
         IRemoteAccountRouter_factory["factory(): IRemoteAccountFactory"]
         IRemoteAccountRouter_permit2["permit2(): IPermit2"]
         IRemoteAccountRouter_processProvideRemoteAccountInstruction[processProvideRemoteAccountInstruction]
         IRemoteAccountRouter_processRemoteAccountExecuteInstruction[processRemoteAccountExecuteInstruction]
-        IRemoteAccountRouter_processUpdateOwnerInstruction[processUpdateOwnerInstruction]
-        subgraph IRemoteAccountRouter_state[state]
-            successor["successor(): address"]
-        end
+        IRemoteAccountRouter_adminInstructions["processEnableRouterInstruction<br>processDisableRouterInstruction<br>processConfirmVettingAuthorityInstruction"]
         %% events
         OperationResult@{shape: flag}
     end
@@ -133,18 +129,17 @@ graph TB
         processProvideRemoteAccountInstruction_self@{shape: comment, label: "require self-call"}
         processRemoteAccountExecuteInstruction["processRemoteAccountExecuteInstruction<br>override IRemoteAccountRouter"]
         processRemoteAccountExecuteInstruction_self@{shape: comment, label: "require self-call"}
-        processUpdateOwnerInstruction["processUpdateOwnerInstruction<br>override IRemoteAccountRouter"]
-        processUpdateOwnerInstruction_self@{shape: comment, label: "require self-call"}
-        ISFACTORY{for factory}
+        adminInstructions["processEnableRouterInstruction |<br>processDisableRouterInstruction |<br>processConfirmVettingAuthorityInstruction"]
+        adminInstructions_self@{shape: comment, label: "require self-call"}
+        VERIFY_PRINCIPAL@{shape: text, label: "verify factory<br>principal"}
         DEP@{shape: text, label: "Permit2 Integration"}
         PROV@{shape: text, label: "account creation/<br>verification"}
         MULTI@{shape: text, label: "account use"}
-        setSuccessor
+        ADMIN_CALL@{shape: text, label: "factory admin call<br>(enableRouter |<br>disableRouter |<br>confirmVettingAuthorityTransfer)"}
         subgraph state
             factory@{shape: stored-data, label: "factory: IRemoteAccountFactory<br>override IRemoteAccountRouter"}
             permit2@{shape: stored-data, label: "permit2: IPermit2<br>override IRemoteAccountRouter"}
             axelarSourceChainHash@{shape: stored-data, label: "axelarSourceChainHash: bytes32"}
-            successor@{shape: stored-data, label: "successor: address"}
         end
     end
 
@@ -153,58 +148,50 @@ graph TB
     %% inheritance
     RemoteAccountAxelarRouter -.->|is| AxelarExecutable
     RemoteAccountAxelarRouter -.->|is| IRemoteAccountRouter
-    RemoteAccountAxelarRouter -.->|is| ImmutableOwnable
 
     %% operation
     START --> _execute
-    START --> setSuccessor
     _execute -->|"[1]"| VALIDATE
     _execute -->|"[2]"| DECODE
     DECODE -.-> processProvideRemoteAccountInstruction
     DECODE -.-> processRemoteAccountExecuteInstruction
-    DECODE -.-> processUpdateOwnerInstruction
+    DECODE -.-> adminInstructions
     processProvideRemoteAccountInstruction --> processProvideRemoteAccountInstruction_self
-    processProvideRemoteAccountInstruction -.->|"[1] effect deposit"| DEP
-    processProvideRemoteAccountInstruction -->|"[2] provide account"| PROV
-    processRemoteAccountExecuteInstruction -->|"[1] provide account"| PROV
+    processProvideRemoteAccountInstruction -->|"[1]"| VERIFY_PRINCIPAL
+    processProvideRemoteAccountInstruction -.->|"[2] effect deposit"| DEP
+    processProvideRemoteAccountInstruction -->|"[3] provide account"| PROV
     processRemoteAccountExecuteInstruction --> processRemoteAccountExecuteInstruction_self
+    processRemoteAccountExecuteInstruction -->|"[1] provide account"| PROV
     processRemoteAccountExecuteInstruction -->|"[2] send calls"| MULTI
+    adminInstructions --> adminInstructions_self
+    adminInstructions -->|"[1]"| VERIFY_PRINCIPAL
+    adminInstructions -->|"[2]"| ADMIN_CALL
     _execute -->|"[3] emit"| OperationResult
 
     %% state/dependency access
     VALIDATE -->|checks| axelarSourceChainHash
     DEP -->|call<br>permitWitnessTransferFrom| permit2
+    VERIFY_PRINCIPAL -->|call verifyFactoryPrincipalAccount| factory
     PROV -->|call provideRemoteAccount| factory
     MULTI --> |call executeCalls| RAn
-    processUpdateOwnerInstruction --> processUpdateOwnerInstruction_self
-    processUpdateOwnerInstruction --> ISFACTORY
-    ISFACTORY -->|"[2] call provideRemoteAccount"| factory
-    ISFACTORY -->|"[3] call transferOwnership"| RAn
-    ISFACTORY -->|"[2] verify principal"| factory
-    ISFACTORY -->|"[3] call transferOwnership"| factory
-    processUpdateOwnerInstruction -->|"[1] checks"| successor
-    setSuccessor -->|updates| successor
-    setSuccessor -->|modifier| onlyOwner
-    onlyOwner -->|checks| owner
+    ADMIN_CALL -->|call| factory
 
     style _execute fill:#ffe6e6
-    style setSuccessor fill:#ffe6e6
     style processProvideRemoteAccountInstruction fill:#fff0e6
     style processRemoteAccountExecuteInstruction fill:#fff0e6
-    style processUpdateOwnerInstruction fill:#fff0e6
+    style adminInstructions fill:#fff0e6
     style RAn fill:#ccccff
 ```
 
 **Key Components**:
 
-- **\_execute**: Validates source chain, decodes the RouterInstruction selector + payload
+- **\_execute**: Validates source chain, decodes the instruction selector + payload, dispatches to processor
 - **processProvideRemoteAccountInstruction**: Atomically redeems an optional deposit permit and provisions/verifies a RemoteAccount via the factory
 - **processRemoteAccountExecuteInstruction**: Atomically provisions/verifies a RemoteAccount and executes its multicall batch
-- **processUpdateOwnerInstruction**: Transfers factory or remote account ownership to a new router
+- **processEnableRouterInstruction / processDisableRouterInstruction / processConfirmVettingAuthorityInstruction**: Admin instructions that verify the factory principal, then call the corresponding factory method (requires factory principal)
 - **Permit2 Integration**: Transfers tokens to RemoteAccount via Permit2 signature-based transfers
 - **account creation/verification**: Creates or verifies RemoteAccount via factory
 - **account use**: Instructs RemoteAccount to execute arbitrary multicalls
-- **setSuccessor**: Enables ownership transfer to new router versions
 
 ---
 
@@ -218,15 +205,6 @@ graph TB
         %% modifiers
         initializer@{shape: odd}
     end
-    subgraph Ownable
-        _owner
-        owner
-        transferOwnership
-        renounceOwnership
-        _transferOwnership
-        %% modifiers
-        onlyOwner@{shape: odd}
-    end
     subgraph IRemoteAccount
         IRemoteAccount_executeCalls[executeCalls]
     end
@@ -236,12 +214,16 @@ graph TB
         CTOR[constructor]
         initialize
         executeCalls
+        AUTH_CHECK@{shape: text, label: "check factory.isAuthorizedRouter"}
+        subgraph state
+            factory_ref@{shape: stored-data, label: "factory: address"}
+        end
     end
 
     EXTERNAL[target contracts]
+    FACTORY[RemoteAccountFactory]
 
     %% inheritance
-    RemoteAccount -.->|is| Ownable
     RemoteAccount -.->|is| Initializable
     RemoteAccount -.->|is| IRemoteAccount
     executeCalls -.->|override| IRemoteAccount_executeCalls
@@ -250,39 +232,29 @@ graph TB
     START --> CTOR
     START --> initialize
     START --> executeCalls
-    START --> transferOwnership
-    START --> renounceOwnership
-    START --> owner
     CTOR -->|calls| _disableInitializers
     initialize -->|modifier| initializer
-    initialize -->|calls| _transferOwnership
-    executeCalls -->|modifier| onlyOwner
-    executeCalls -.->|loops & calls| EXTERNAL
-    transferOwnership -->|modifier| onlyOwner
-    transferOwnership -->|calls| _transferOwnership
-    renounceOwnership -->|modifier| onlyOwner
-    renounceOwnership -->|calls| _transferOwnership
-    owner -->|reads| _owner
+    initialize -->|sets| factory_ref
+    executeCalls -->|"[1]"| AUTH_CHECK
+    executeCalls -.->|"[2] loops & calls"| EXTERNAL
 
-    %% state access
-    onlyOwner -->|checks| _owner
-    _transferOwnership -->|updates| _owner
+    %% state/dependency access
+    AUTH_CHECK -->|call isAuthorizedRouter| FACTORY
     initializer -->|checks and updates| _initialized
     _disableInitializers -->|updates| _initialized
 
-    style owner fill:#ffe6e6
     style executeCalls fill:#ffe6e6
     style initialize fill:#ffe6e6
-    style transferOwnership fill:#ffe6e6
-    style renounceOwnership fill:#ffe6e6
 ```
 
 **Key Components**:
 
-- **initialize**: One-time ownership initialization for clone instances
-- **executeCalls**: Validates owner, then atomically executes array of contract calls
+- **initialize**: One-time factory reference initialization for clone instances
+- **executeCalls**: Checks authorization via `factory.isAuthorizedRouter(msg.sender)`, then atomically executes array of contract calls
 
-## C4 Level 3: Component Diagram - RemoteAccountFactory
+## C4 Level 3: Component Diagrams - RemoteAccountFactory
+
+### Remote Account Operations
 
 ```mermaid
 graph TB
@@ -290,19 +262,12 @@ graph TB
         cloneDeterministic
         predictDeterministicAddress
     end
-    subgraph Ownable
-        owner
-        transferOwnership
-        renounceOwnership
-        %% modifiers
-        onlyOwner@{shape: odd}
-    end
     subgraph IRemoteAccountFactory
         IRemoteAccountFactory_verifyFactoryPrincipalAccount[verifyFactoryPrincipalAccount]
         IRemoteAccountFactory_getRemoteAccountAddress[getRemoteAccountAddress]
         IRemoteAccountFactory_verifyRemoteAccount[verifyRemoteAccount]
         IRemoteAccountFactory_provideRemoteAccount[provideRemoteAccount]
-        IRemoteAccountFactory_provideRemoteAccountForOwner[provideRemoteAccountForOwner]
+        IRemoteAccountFactory_isAuthorizedRouter[isAuthorizedRouter]
         %% events
         RemoteAccountCreated@{shape: flag}
     end
@@ -314,14 +279,12 @@ graph TB
 
         verifyRemoteAccount["verifyRemoteAccount<br>override IRemoteAccountFactory"]
         _verifyRemoteAccountAddress
-        _verifyRemoteAccountOwner
 
         provideRemoteAccount["provideRemoteAccount<br>override IRemoteAccountFactory"]
-        provideRemoteAccountForOwner["provideRemoteAccountForOwner<br>override IRemoteAccountFactory"]
-        SAME_OWNER{owner matches<br>expected owner?}
-        _createRemoteAccountForOwner
+        _createRemoteAccount
         ACCOUNT_EXISTS{account exists?}
-        ACCOUNT_EXISTS_FOR_OWNER{"account exists?<br>(ForOwner)"}
+
+        isAuthorizedRouter["isAuthorizedRouter<br>override IRemoteAccountFactory"]
 
         CODE_EXISTS["checks code exists"]
         _getSalt[_getSalt<br>deterministic by principal account string]
@@ -330,39 +293,29 @@ graph TB
             factoryPrincipalAccount@{shape: stored-data}
             _principalSalt@{shape: stored-data}
             implementation@{shape: stored-data}
+            _routerStatus@{shape: stored-data, label: "_routerStatus: mapping<br>(Unknown | Vetted | Enabled)"}
         end
     end
 
     RAn[RemoteAccount N]
 
     %% inheritance
-    RemoteAccountFactory -.->|is| Ownable
     RemoteAccountFactory -.->|is| IRemoteAccountFactory
 
     %% operation
     START --> provideRemoteAccount
-    START --> provideRemoteAccountForOwner
     START --> verifyRemoteAccount
     START --> getRemoteAccountAddress
-    START --> transferOwnership
-    START --> renounceOwnership
+    START --> isAuthorizedRouter
+
     provideRemoteAccount --> _verifyRemoteAccountAddress
     provideRemoteAccount --> CODE_EXISTS
     provideRemoteAccount --> ACCOUNT_EXISTS
-    ACCOUNT_EXISTS -.->|yes: calls| _verifyRemoteAccountOwner
-    ACCOUNT_EXISTS -.->|no| SAME_OWNER
-    SAME_OWNER -->|yes: calls| _createRemoteAccountForOwner
-
-    provideRemoteAccountForOwner -->|modifier| onlyOwner
-    provideRemoteAccountForOwner --> _verifyRemoteAccountAddress
-    provideRemoteAccountForOwner --> CODE_EXISTS
-    provideRemoteAccountForOwner --> ACCOUNT_EXISTS_FOR_OWNER
-    ACCOUNT_EXISTS_FOR_OWNER -.->|yes: calls| _verifyRemoteAccountOwner
-    ACCOUNT_EXISTS_FOR_OWNER -->|no: calls| _createRemoteAccountForOwner
+    ACCOUNT_EXISTS -.->|yes: return false| provideRemoteAccount
+    ACCOUNT_EXISTS -->|no: calls| _createRemoteAccount
 
     verifyRemoteAccount -->|calls| _verifyRemoteAccountAddress
     verifyRemoteAccount --> CODE_EXISTS
-    verifyRemoteAccount -->|calls| _verifyRemoteAccountOwner
 
     _verifyRemoteAccountAddress -->|calls| _getRemoteAccountAddress
     _getRemoteAccountAddress -->|calls| _getSalt
@@ -370,40 +323,144 @@ graph TB
 
     CODE_EXISTS -.-> RAn
 
-    _verifyRemoteAccountOwner -.->|"call owner()"| RAn
-    _createRemoteAccountForOwner -->|calls| cloneDeterministic
+    _createRemoteAccount -->|calls| cloneDeterministic
     cloneDeterministic -->|"CREATE2"| RAn
-    _createRemoteAccountForOwner -->|initialize| RAn
-    _createRemoteAccountForOwner -->|"emit"| RemoteAccountCreated
+    _createRemoteAccount -->|"initialize(factory)"| RAn
+    _createRemoteAccount -->|"emit"| RemoteAccountCreated
 
     getRemoteAccountAddress -->|calls| _getRemoteAccountAddress
+
+    isAuthorizedRouter -->|reads| _routerStatus
 
     %% state access
     _getRemoteAccountAddress -.->|reads| _principalSalt
     _getRemoteAccountAddress -.->|reads| implementation
-    _verifyRemoteAccountOwner -.->|checks| owner
-    SAME_OWNER -.->|checks| owner
-    onlyOwner -.->|checks| owner
-    transferOwnership -->|updates| owner
-    renounceOwnership -->|updates| owner
 
     style provideRemoteAccount fill:#ffe6e6
-    style provideRemoteAccountForOwner fill:#ffe6e6
     style verifyRemoteAccount fill:#ffe6e6
     style getRemoteAccountAddress fill:#ffe6e6
-    style transferOwnership fill:#ffe6e6
-    style renounceOwnership fill:#ffe6e6
+    style isAuthorizedRouter fill:#ffe6e6
 ```
 
-**Key Components**:
+### Router & Vetting Authority Administration
 
-- **provideRemoteAccount**: Public method requiring new account owner is current factory owner.
-- **provideRemoteAccountForOwner**: Owner-only method to create or verify accounts for an arbitrary owner
-- **verifyRemoteAccount**: Multi-layer verification of existing accounts (code, principal, owner)
+```mermaid
+graph TB
+    subgraph IRemoteAccountFactory
+        IRemoteAccountFactory_isAuthorizedRouter[isAuthorizedRouter]
+        IRemoteAccountFactory_enableRouter[enableRouter]
+        IRemoteAccountFactory_disableRouter[disableRouter]
+        IRemoteAccountFactory_confirmVettingAuthorityTransfer[confirmVettingAuthorityTransfer]
+        %% events
+        RouterVetted@{shape: flag}
+        RouterEnabled@{shape: flag}
+        RouterDisabled@{shape: flag}
+        RouterRevoked@{shape: flag}
+        VettingAuthorityTransferProposed@{shape: flag}
+        VettingAuthorityTransferred@{shape: flag}
+    end
+
+    subgraph RemoteAccountFactory
+        START@{shape: start}
+
+        isAuthorizedRouter["isAuthorizedRouter<br>override IRemoteAccountFactory"]
+        getRouterStatus
+
+        subgraph "EVM-sourced (vetting authority)"
+            CHECK_VA@{shape: text, label: "check msg.sender ==<br>vettingAuthority"}
+            vetRouter
+            revokeRouter
+            proposeVettingAuthorityTransfer
+        end
+
+        subgraph "Agoric-sourced (enabled router)"
+            CHECK_ROUTER@{shape: text, label: "check isAuthorizedRouter<br>(msg.sender)"}
+            enableRouter["enableRouter<br>override IRemoteAccountFactory"]
+            disableRouter["disableRouter<br>override IRemoteAccountFactory"]
+            confirmVettingAuthorityTransfer["confirmVettingAuthorityTransfer<br>override IRemoteAccountFactory"]
+        end
+
+        subgraph state
+            _routerStatus@{shape: stored-data, label: "_routerStatus: mapping<br>(Unknown | Vetted | Enabled)"}
+            vettingAuthority@{shape: stored-data}
+            _pendingVettingAuthority@{shape: stored-data}
+        end
+    end
+
+    %% inheritance
+    RemoteAccountFactory -.->|is| IRemoteAccountFactory
+
+    %% operation
+    START --> isAuthorizedRouter
+    START --> getRouterStatus
+    START --> vetRouter
+    START --> enableRouter
+    START --> disableRouter
+    START --> revokeRouter
+    START --> proposeVettingAuthorityTransfer
+    START --> confirmVettingAuthorityTransfer
+
+    isAuthorizedRouter -->|reads| _routerStatus
+    getRouterStatus -->|reads| _routerStatus
+
+    %% EVM-sourced operations (vetting authority)
+    vetRouter -->|"[1]"| CHECK_VA
+    vetRouter -->|"[2] updates"| _routerStatus
+    vetRouter -->|emit| RouterVetted
+
+    revokeRouter -->|"[1]"| CHECK_VA
+    revokeRouter -->|"[2] updates"| _routerStatus
+    revokeRouter -->|emit| RouterRevoked
+
+    proposeVettingAuthorityTransfer -->|"[1]"| CHECK_VA
+    proposeVettingAuthorityTransfer -->|"[2] updates"| _pendingVettingAuthority
+    proposeVettingAuthorityTransfer -->|emit| VettingAuthorityTransferProposed
+
+    CHECK_VA -->|checks| vettingAuthority
+
+    %% Agoric-sourced operations (enabled router)
+    enableRouter -->|"[1]"| CHECK_ROUTER
+    enableRouter -->|"[2] updates"| _routerStatus
+    enableRouter -->|emit| RouterEnabled
+
+    disableRouter -->|"[1]"| CHECK_ROUTER
+    disableRouter -->|"[2] updates"| _routerStatus
+    disableRouter -->|emit| RouterDisabled
+
+    confirmVettingAuthorityTransfer -->|"[1]"| CHECK_ROUTER
+    confirmVettingAuthorityTransfer -->|"[2] checks"| _pendingVettingAuthority
+    confirmVettingAuthorityTransfer -->|"[3] updates"| vettingAuthority
+    confirmVettingAuthorityTransfer -->|emit| VettingAuthorityTransferred
+
+    CHECK_ROUTER -->|calls| isAuthorizedRouter
+
+    style isAuthorizedRouter fill:#ffe6e6
+    style vetRouter fill:#ffe6e6
+    style enableRouter fill:#ffe6e6
+    style disableRouter fill:#ffe6e6
+    style revokeRouter fill:#ffe6e6
+    style proposeVettingAuthorityTransfer fill:#ffe6e6
+    style confirmVettingAuthorityTransfer fill:#ffe6e6
+```
+
+**Key Components (Remote Account Operations)**:
+
+- **provideRemoteAccount**: Creates or verifies a remote account at the expected address derived from the principal
+- **verifyRemoteAccount**: Multi-layer verification of existing accounts (code, principal)
 - **verifyFactoryPrincipalAccount**: Validates the factory principal account string
-- **\_verifyRemoteAccountAddress**: Enforces principal-to-address derivation before creation/verification.
-- **\_getRemoteAccountAddress**: Rejects the factory principal account (prevents treating factory as a remote account).
-- **\_createRemoteAccountForOwner**: Core deterministic clone deployment + ownership initialization.
+- **\_verifyRemoteAccountAddress**: Enforces principal-to-address derivation before creation/verification
+- **\_getRemoteAccountAddress**: Rejects the factory principal account (prevents treating factory as a remote account)
+- **\_createRemoteAccount**: Core deterministic clone deployment + factory reference initialization
+- **isAuthorizedRouter**: Checks if a caller is an enabled router
+
+**Key Components (Router & Vetting Authority Administration)**:
+
+- **vetRouter**: Marks a router as vetted (vetting authority only)
+- **enableRouter**: Enables a vetted router (enabled router only)
+- **disableRouter**: Disables an enabled router (enabled router only, not self)
+- **revokeRouter**: Revokes a vetted router (vetting authority only)
+- **proposeVettingAuthorityTransfer**: Proposes a new vetting authority (current vetting authority only)
+- **confirmVettingAuthorityTransfer**: Confirms the pending vetting authority transfer (enabled router only)
 
 ## Data Flow: Account creation and use
 
@@ -418,13 +475,15 @@ sequenceDiagram
     participant DEFI as DeFi Protocol
 
     Note right of PM: using portfolio LCA
-    PM->>AXL: send ProvideRemoteAccountInstruction |<br>RemoteAccountExecuteInstruction |<br>UpdateOwnerInstruction
+    PM->>AXL: send ProvideRemoteAccountInstruction |<br>RemoteAccountExecuteInstruction |<br>EnableRouterInstruction |<br>DisableRouterInstruction |<br>ConfirmVettingAuthorityInstruction
     AXL->>PR: _execute(sourceChain,<br>sourceAddress, payload)
 
     PR->>PR: validate source chain
 
     critical
         alt processProvideRemoteAccountInstruction
+            PR->>RAF: verifyFactoryPrincipalAccount(sourceAddress)
+
             Note over PR,RA: pull deposit
             opt if depositPermit exists
                 PR->>P2: permitWitnessTransferFrom(...)
@@ -432,53 +491,43 @@ sequenceDiagram
             end
 
             Note over PR,RA: provide account
-            PR->>RAF: provideRemoteAccount(instruction.principalAccount,<br> address(this), expectedAddress)
+            PR->>RAF: provideRemoteAccount(instruction.principalAccount,<br> expectedAddress)
             alt if exists
-                RAF->>RA: owner()
-                RAF->>RAF: verify match
+                RAF->>RAF: verify address
             else
                 RAF->>RA: cloneDeterministic
-                RAF->>RA: initialize(router)
+                RAF->>RA: initialize(factory)
             end
         else processRemoteAccountExecuteInstruction
             Note over PR,RA: provide account
-            PR->>RAF: provideRemoteAccount(sourceAddress, address(this), expectedAddress)
+            PR->>RAF: provideRemoteAccount(sourceAddress, expectedAddress)
             alt if exists
-                RAF->>RA: owner()
-                RAF->>RAF: verify match
+                RAF->>RAF: verify address
             else
                 RAF->>RA: cloneDeterministic
-                RAF->>RA: initialize(router)
+                RAF->>RA: initialize(factory)
             end
 
             Note over PR,RA: make calls
             opt if multiCalls exist
                 PR->>RA: executeCalls(multiCalls)
-                RA->>RA: Validate owner
+                RA->>RAF: isAuthorizedRouter(msg.sender)
+                RAF-->>RA: true
                 loop for each {target, data, value, gasLimit}
                     RA->>DEFI: target.call{value, gas: gasLimit}(data)
                     Note over RA,DEFI: gasLimit is optional (0 means no explicit gas)
                     DEFI-->>RA: result
                 end
             end
-        else processUpdateOwnerInstruction
-            PR->>PR: verify newOwner is successor
-
-            Note over PR,RA: provide account / verify principal, then transfer
-            alt expectedAddress == factory
-                PR->>RAF: verifyFactoryPrincipalAccount(sourceAddress)
-                PR->>RAF: transferOwnership(newOwner)
-            else
-                PR->>RAF: provideRemoteAccount(sourceAddress, address(this), expectedAddress)
-                alt if exists
-                    RAF->>RA: owner()
-                    RAF->>RAF: verify match
-                else
-                    RAF->>RA: cloneDeterministic
-                    RAF->>RA: initialize(router)
-                end
-                PR->>RA: transferOwnership(newOwner)
-            end
+        else processEnableRouterInstruction
+            PR->>RAF: verifyFactoryPrincipalAccount(sourceAddress)
+            PR->>RAF: enableRouter(instruction.router)
+        else processDisableRouterInstruction
+            PR->>RAF: verifyFactoryPrincipalAccount(sourceAddress)
+            PR->>RAF: disableRouter(instruction.router)
+        else processConfirmVettingAuthorityInstruction
+            PR->>RAF: verifyFactoryPrincipalAccount(sourceAddress)
+            PR->>RAF: confirmVettingAuthorityTransfer(instruction.authority)
         end
     option [success]
         PR->>PR: emit OperationResult(id, true, '')
@@ -493,15 +542,21 @@ sequenceDiagram
 2. RemoteAccountAxelarRouter validates message source
 3. RemoteAccountAxelarRouter parses and processes input
     - For `processProvideRemoteAccountInstruction`:
-        1. If requested, RemoteAccountAxelarRouter transfers tokens via Permit2
-        2. RemoteAccountAxelarRouter provides account (creating if necessary)
+        1. RemoteAccountAxelarRouter verifies the factory principal matches the source address
+        2. If requested, RemoteAccountAxelarRouter transfers tokens via Permit2
+        3. RemoteAccountAxelarRouter provides account (creating if necessary)
     - For `processRemoteAccountExecuteInstruction`:
         1. RemoteAccountAxelarRouter provides account (creating if necessary)
-        2. If calls for RemoteAccount exist, RemoteAccountAxelarRouter forwards them and RemoteAccount executes them
-    - For `processUpdateOwnerInstruction`:
-        1. RemoteAccountAxelarRouter verifies that the new owner identifies its successor
-        2. RemoteAccountAxelarRouter provides account (creating if necessary), or verifies the factory principal
-        3. RemoteAccountAxelarRouter transfers account ownership
+        2. If calls for RemoteAccount exist, RemoteAccountAxelarRouter forwards them; RemoteAccount verifies the caller is an authorized router via the factory, then executes them
+    - For `processEnableRouterInstruction`:
+        1. RemoteAccountAxelarRouter verifies the factory principal matches the source address
+        2. RemoteAccountAxelarRouter enables a vetted router on the factory
+    - For `processDisableRouterInstruction`:
+        1. RemoteAccountAxelarRouter verifies the factory principal matches the source address
+        2. RemoteAccountAxelarRouter disables an enabled router on the factory
+    - For `processConfirmVettingAuthorityInstruction`:
+        1. RemoteAccountAxelarRouter verifies the factory principal matches the source address
+        2. RemoteAccountAxelarRouter confirms the pending vetting authority transfer on the factory
 4. RemoteAccountAxelarRouter emits an event describing success or failure
 
 ## Ownership and Security Model
@@ -509,111 +564,102 @@ sequenceDiagram
 ```mermaid
 graph TB
     Axelar
-    EVM_OPERATOR["EVM operator multisig"]
-    ROUTER1[old RemoteAccountAxelarRouter v1]
-    ROUTER2[old RemoteAccountAxelarRouter v2]
-    ROUTERn[RemoteAccountAxelarRouter v3]
+    VA["Vetting Authority<br/>(EVM multisig)"]
+    ROUTER1[RemoteAccountAxelarRouter v1<br/>enabled]
+    ROUTER2[RemoteAccountAxelarRouter v2<br/>vetted, not yet enabled]
     RAF[RemoteAccountFactory]
-    RA1["old RemoteAccount<br>(untouched by v2+)"]
-    RA2["old RemoteAccount<br>(touched by v3)"]
-    RAn[new RemoteAccount]
+    RA[RemoteAccount]
 
     Axelar -->|_execute| ROUTER1
-    Axelar -->|_execute| ROUTER2
-    Axelar -->|_execute| ROUTERn
 
-    EVM_OPERATOR -.->|setSuccessor| ROUTER1
-    EVM_OPERATOR -.->|setSuccessor| ROUTER2
-    EVM_OPERATOR -.->|setSuccessor| ROUTERn
+    VA -->|"vetRouter |<br>revokeRouter |<br>proposeVettingAuthorityTransfer"| RAF
 
-    ROUTER1 ==>|owns| RA1
-    ROUTER1 -.->|transferred| RA2
-    ROUTER1 -.->|transferred| RAF
-    ROUTER1 -.->|old successor| ROUTER2
-    ROUTER1 -->|successor| ROUTERn
-    ROUTER2 -.->|transferred| RAF
-    ROUTER2 -->|successor| ROUTERn
-    ROUTERn ==>|owns| RA2
-    ROUTERn ==>|owns| RAn
-    ROUTERn ==>|owns| RAF
+    ROUTER1 ==>|executeCalls| RA
+
+    ROUTER1 -->|"enableRouter |<br>disableRouter |<br>confirmVettingAuthorityTransfer"| RAF
+
+    RAF ==>|creates & initializes| RA
+
+    RA -.->|isAuthorizedRouter| RAF
 
     style Axelar fill:#ffe6e6
-    style EVM_OPERATOR fill:#ffe6e6
-    style ROUTER1 fill:#e8e8e8
+    style VA fill:#ffe6e6
+    style ROUTER1 fill:#e6ffe6
     style ROUTER2 fill:#e8e8e8
-    style ROUTERn fill:#e6ffe6
+    style RAF fill:#ccffcc
 ```
 
-**Ownership**:
+**Transitive Ownership**:
 
-- Current RemoteAccountAxelarRouter owns RemoteAccountFactory and all new accounts
-- Ownership of old accounts is transferred upon activity (`transferOwnership` call through old router)
+- RemoteAccountFactory maintains a router authorization map with statuses: Unknown, Vetted, Enabled
+- RemoteAccount delegates authorization to its factory: any enabled router can execute calls on any account
+- Router migrations are O(1): enabling a new router instantly authorizes it for all accounts
+
+**Two-Factor Router Authorization**:
+
+- **Vetting** (EVM-side): The factory's vetting authority (e.g. multisig) can vet or revoke routers via direct calls
+- **Enabling** (Agoric-side): The factory's principal can enable or disable vetted routers via GMP messages through an enabled router
+- A router must be both vetted and enabled to operate on remote accounts
 
 **Security Checks**:
 
-- **RemoteAccountAxelarRouter `setSuccessor`**: Validate `msg.sender` against immutable `owner`
 - **RemoteAccountAxelarRouter `_execute`**: Validate `sourceChain` against immutable hash
-- **RemoteAccountAxelarRouter `processProvideRemoteAccountInstruction`**: Validate the source address as the factory principal. This ensures only the portfolio manager can redeem signed permit2 intents.
-- **RemoteAccountFactory `provideRemoteAccount`**: For account creation, validate requested owner against its own owner. Validates remote account address derives from sourceAddress.
-- **RemoteAccountFactory/RemoteAccount `executeCalls` and `transferOwnership`**: Validate that sender is current owner
+- **RemoteAccountAxelarRouter admin instructions**: Validate the source address as the factory principal (ensures only the portfolio manager can manage routers or redeem signed permits)
+- **RemoteAccountFactory `provideRemoteAccount`**: Validates remote account address derives from the principal account string
+- **RemoteAccountFactory `vetRouter`/`revokeRouter`**: Only the vetting authority can call these
+- **RemoteAccountFactory `enableRouter`/`disableRouter`**: Only an already-enabled router can call these (preventing unauthorized routers from self-enabling)
+- **RemoteAccountFactory `disableRouter`**: A router cannot disable itself
+- **RemoteAccount `executeCalls`**: Validates that the caller is an authorized router via `factory.isAuthorizedRouter(msg.sender)`
 
 ## Deployment
 
 ```mermaid
 sequenceDiagram
     participant PM as Portfolio Manager<br>(Agoric)
+    participant VA as Vetting Authority<br>(EVM multisig)
     participant EVM_DEPLOYER as EVM deployer
-    participant EVM_OPERATOR as EVM operator<br>multisig
     participant ROUTER1 as RemoteAccountAxelarRouter<br>v1
-    participant ROUTER2 as RemoteAccountAxelarRouter<br>v2
-    participant ROUTERn as RemoteAccountAxelarRouter<br>v3
+    participant ROUTERn as RemoteAccountAxelarRouter<br>v2
     participant IMP as RemoteAccount<br>implementation
     participant RAF as RemoteAccountFactory
     participant RA as RemoteAccount
 
     Note over PM,RA: Initial deployment
     EVM_DEPLOYER->>IMP: deploy
-    EVM_DEPLOYER->>IMP: renounceOwnership
-    EVM_DEPLOYER->>RAF: deploy
-    EVM_DEPLOYER->>ROUTER1: deploy
-    EVM_DEPLOYER->>RAF: transferOwnership to router
+    EVM_DEPLOYER->>RAF: deploy(principal, impl,<br>initialRouter=predicted ROUTER1 addr,<br>vettingAuthority=VA)
+    EVM_DEPLOYER->>ROUTER1: deploy(gateway, sourceChain, factory=RAF, permit2)
 
-    Note over PM,RA: Deploy new router
-    EVM_DEPLOYER->>ROUTERn: deploy
+    Note over PM,RA: Normal operations
+    PM->>ROUTER1: [via Axelar] processRemoteAccountExecuteInstruction
+    ROUTER1->>RAF: provideRemoteAccount
+    RAF-->>RA: create/validate
+    ROUTER1->>RA: executeCalls
+    RA->>RAF: isAuthorizedRouter(ROUTER1)?
+    RAF-->>RA: true
 
-    Note over PM,RA: Update old routers
-    par
-        EVM_OPERATOR->>ROUTER1: setSuccessor(new router)
-        EVM_OPERATOR->>ROUTER2: setSuccessor(new router)
-    end
+    Note over PM,RA: Deploy and vet new router
+    EVM_DEPLOYER->>ROUTERn: deploy(gateway, sourceChain, factory=RAF, permit2)
+    VA->>RAF: vetRouter(ROUTERn)
 
-    Note over PM,RA: Upgrade contract for new router
-    PM->>PM: upgrade
-    PM->>ROUTER2: [via Axelar] send (processUpdateOwnerInstruction, txId, factoryAddr, UpdateOwnerInstruction{newRouterAddr})
-    ROUTER2->>RAF: transferOwnership(newRouterAddr)
-    RAF->>RAF: confirm sender is current owner
-    RAF->>RAF: replace owner
-    ROUTER2->>PM: [via Resolver] ready
-    PM->>PM: new router ready
+    Note over PM,RA: Enable new router (via GMP)
+    PM->>ROUTER1: [via Axelar] processEnableRouterInstruction(ROUTERn)
+    ROUTER1->>RAF: enableRouter(ROUTERn)
 
-    Note over PM,RA: Account interactions
-    opt if account uses old router
-        PM->>ROUTER1: [via Axelar] send (processUpdateOwnerInstruction, txId, addr, UpdateOwnerInstruction{newRouterAddr})
-        ROUTER1->>RAF: provideRemoteAccount
-        RAF-->>RA: create/validate
-        ROUTER1->>RA: transferOwnership(newRouterAddr)
-        RA->>RA: confirm sender is current owner
-        RA->>RA: replace owner
-    end
-    PM->>ROUTERn: [via Axelar] send (processRemoteAccountExecuteInstruction, txId, expectedAddr, RemoteAccountExecuteInstruction{...})
+    Note over PM,RA: Both routers now operational
+    PM->>ROUTERn: [via Axelar] processRemoteAccountExecuteInstruction
     ROUTERn->>RAF: provideRemoteAccount
     RAF-->>RA: create/validate
     ROUTERn->>RA: executeCalls
+
+    Note over PM,RA: Optionally disable old router (via GMP)
+    PM->>ROUTERn: [via Axelar] processDisableRouterInstruction(ROUTER1)
+    ROUTERn->>RAF: disableRouter(ROUTER1)
 ```
 
 **Migration Features**:
 
-- Non-disruptive: Can migrate one account at a time
-- Safe: Requires both owner of old router and portfolio manager agreement
-- Flexible: RemoteAccount addresses remain constant
-- Auditable: All account changes performed via cross-chain messages.
+- **O(1) migration**: Enabling a new router instantly authorizes it for all existing accounts — no per-account ownership transfer needed
+- **Non-disruptive**: Old and new routers can coexist during migration
+- **Two-factor safety**: Router changes require agreement from both the vetting authority (EVM) and the factory principal (Agoric)
+- **Flexible**: RemoteAccount addresses remain constant across router upgrades
+- **Auditable**: All router changes are emitted as events; principal-initiated changes flow through GMP messages

--- a/packages/axelar-local-dev-cosmos/src/contracts/design.md
+++ b/packages/axelar-local-dev-cosmos/src/contracts/design.md
@@ -325,7 +325,7 @@ graph TB
 
     _createRemoteAccount -->|calls| cloneDeterministic
     cloneDeterministic -->|"CREATE2"| RAn
-    _createRemoteAccount -->|"initialize(factory)"| RAn
+    _createRemoteAccount -->|"initialize(factory, principalAccount)"| RAn
     _createRemoteAccount -->|"emit"| RemoteAccountCreated
 
     getRemoteAccountAddress -->|calls| _getRemoteAccountAddress
@@ -548,7 +548,7 @@ sequenceDiagram
                 RAF->>RAF: verify address
             else
                 RAF->>RA: cloneDeterministic
-                RAF->>RA: initialize(factory)
+                RAF->>RA: initialize(factory, principalAccount)
             end
         else processRemoteAccountExecuteInstruction
             Note over PR,RA: provide account
@@ -557,7 +557,7 @@ sequenceDiagram
                 RAF->>RAF: verify address
             else
                 RAF->>RA: cloneDeterministic
-                RAF->>RA: initialize(factory)
+                RAF->>RA: initialize(factory, principalAccount)
             end
 
             Note over PR,RA: make calls
@@ -678,7 +678,7 @@ sequenceDiagram
 
     Note over PM,RA: Initial deployment
     EVM_DEPLOYER->>IMP: deploy
-    EVM_DEPLOYER->>RAF: deploy(principal, impl,<br>initialRouter=predicted ROUTER1 addr,<br>vettingAuthority=VA)
+    EVM_DEPLOYER->>RAF: deploy(principal, impl,<br>vettingAuthority=VA)
     EVM_DEPLOYER->>ROUTER1: deploy(gateway, sourceChain, factory=RAF, permit2)
     VA->>RAF: vetInitialRouter(ROUTER1)
 

--- a/packages/axelar-local-dev-cosmos/src/contracts/design.md
+++ b/packages/axelar-local-dev-cosmos/src/contracts/design.md
@@ -368,10 +368,13 @@ graph TB
 
         subgraph "EVM-sourced (vetting authority)"
             CHECK_VA@{shape: text, label: "check msg.sender ==<br>vettingAuthority"}
+            vetInitialRouter
             vetRouter
             revokeRouter
             proposeVettingAuthorityTransfer
         end
+
+        _enableRouter["_enableRouter (internal)"]
 
         subgraph "Agoric-sourced (enabled router)"
             CHECK_ROUTER@{shape: text, label: "check isAuthorizedRouter<br>(msg.sender)"}
@@ -381,6 +384,7 @@ graph TB
         end
 
         subgraph state
+            numberOfAuthorizedRouters@{shape: stored-data}
             _routerStatus@{shape: stored-data, label: "_routerStatus: mapping<br>(Unknown | Vetted | Enabled)"}
             vettingAuthority@{shape: stored-data}
             _pendingVettingAuthority@{shape: stored-data}
@@ -393,6 +397,7 @@ graph TB
     %% operation
     START --> isAuthorizedRouter
     START --> getRouterStatus
+    START --> vetInitialRouter
     START --> vetRouter
     START --> enableRouter
     START --> disableRouter
@@ -404,6 +409,10 @@ graph TB
     getRouterStatus -->|reads| _routerStatus
 
     %% EVM-sourced operations (vetting authority)
+    vetInitialRouter -->|"[1] guard"| numberOfAuthorizedRouters
+    vetInitialRouter -->|"[2] calls"| vetRouter
+    vetInitialRouter -->|"[3] calls"| _enableRouter
+
     vetRouter -->|"[1]"| CHECK_VA
     vetRouter -->|"[2] updates"| _routerStatus
     vetRouter -->|emit| RouterVetted
@@ -420,11 +429,15 @@ graph TB
 
     %% Agoric-sourced operations (enabled router)
     enableRouter -->|"[1]"| CHECK_ROUTER
-    enableRouter -->|"[2] updates"| _routerStatus
-    enableRouter -->|emit| RouterEnabled
+    enableRouter -->|"[2] calls"| _enableRouter
+
+    _enableRouter -->|"[1] updates"| _routerStatus
+    _enableRouter -->|"[2] increments"| numberOfAuthorizedRouters
+    _enableRouter -->|emit| RouterEnabled
 
     disableRouter -->|"[1]"| CHECK_ROUTER
     disableRouter -->|"[2] updates"| _routerStatus
+    disableRouter -->|"[3] decrements"| numberOfAuthorizedRouters
     disableRouter -->|emit| RouterDisabled
 
     confirmVettingAuthorityTransfer -->|"[1]"| CHECK_ROUTER
@@ -435,8 +448,10 @@ graph TB
     CHECK_ROUTER -->|calls| isAuthorizedRouter
 
     style isAuthorizedRouter fill:#ffe6e6
+    style vetInitialRouter fill:#ffe6e6
     style vetRouter fill:#ffe6e6
     style enableRouter fill:#ffe6e6
+    style _enableRouter fill:#fff0e6
     style disableRouter fill:#ffe6e6
     style revokeRouter fill:#ffe6e6
     style proposeVettingAuthorityTransfer fill:#ffe6e6
@@ -455,12 +470,49 @@ graph TB
 
 **Key Components (Router & Vetting Authority Administration)**:
 
+- **vetInitialRouter**: Vets and enables the very first router (vetting authority only, no previous router). This initializes the factory.
 - **vetRouter**: Marks a router as vetted (vetting authority only)
 - **enableRouter**: Enables a vetted router (enabled router only)
 - **disableRouter**: Disables an enabled router (enabled router only, not self)
 - **revokeRouter**: Revokes a vetted router (vetting authority only)
 - **proposeVettingAuthorityTransfer**: Proposes a new vetting authority (current vetting authority only)
 - **confirmVettingAuthorityTransfer**: Confirms the pending vetting authority transfer (enabled router only)
+
+## Data Flow: Factory deployment and initial router setup
+
+```mermaid
+sequenceDiagram
+    participant D as Deployer
+    participant V as Vetting Authority
+    participant RA_IMPL as RemoteAccount<br/>(implementation)
+    participant RAF as RemoteAccountFactory
+    participant R as RemoteAccountAxelarRouter
+
+    Note over D: Step 1: Deploy implementation
+    D->>RA_IMPL: deploy()
+    RA_IMPL->>RA_IMPL: _disableInitializers()
+
+    Note over D: Step 2: Deploy factory
+    D->>RAF: deploy(caip2, principalAccount,<br>implementation, vettingAuthority)
+    RAF->>RAF: store immutables
+    RAF->>RA_IMPL: factory() — verify implementation is inert
+
+    Note over D: Step 3: Deploy router
+    D->>R: deploy(gateway, sourceChain,<br>factory, permit2)
+
+    Note over V: Step 4: Bootstrap initial router
+    V->>RAF: vetInitialRouter(router)
+    RAF->>RAF: require numberOfAuthorizedRouters == 0
+    RAF->>RAF: vetRouter(router) — checks vettingAuthority
+    RAF->>RAF: _enableRouter(router)
+    RAF->>RAF: numberOfAuthorizedRouters = 1
+```
+
+**Deployment Notes**:
+
+- The factory constructor does not accept an "initial router" parameter and instead, requires an initialization step (`vetInitialRouter`) from the vetting authority. This avoids creating a circular dependency when constructing the factory and the first router.
+- The vetting authority address is required at construction of the factory. This is to ensure any CREATE2 based deployments cannot be squatted.
+- `vetInitialRouter` is a one-shot bootstrap: it reverts once any router has been authorized (`numberOfAuthorizedRouters > 0`). Subsequent routers follow the normal vet → enable lifecycle via GMP. It's also not possible to revert back to 0 authorized routers.
 
 ## Data Flow: Account creation and use
 
@@ -628,6 +680,7 @@ sequenceDiagram
     EVM_DEPLOYER->>IMP: deploy
     EVM_DEPLOYER->>RAF: deploy(principal, impl,<br>initialRouter=predicted ROUTER1 addr,<br>vettingAuthority=VA)
     EVM_DEPLOYER->>ROUTER1: deploy(gateway, sourceChain, factory=RAF, permit2)
+    VA->>RAF: vetInitialRouter(ROUTER1)
 
     Note over PM,RA: Normal operations
     PM->>ROUTER1: [via Axelar] processRemoteAccountExecuteInstruction

--- a/packages/axelar-local-dev-cosmos/src/contracts/design.md
+++ b/packages/axelar-local-dev-cosmos/src/contracts/design.md
@@ -222,7 +222,7 @@ graph TB
         initialize
         receive
         executeCalls
-        AUTH_CHECK@{shape: text, label: "check factory.isAuthorizedRouter"}
+        AUTH_CHECK@{shape: text, label: "call factory.checkAuthorizedRouter"}
         CALL["process call<br>instruction"]
         subgraph state
             factory_ref@{shape: stored-data, label: "factory: address"}
@@ -255,7 +255,7 @@ graph TB
     receive -->|"emits"| Received
 
     %% state/dependency access
-    AUTH_CHECK -->|call isAuthorizedRouter| FACTORY
+    AUTH_CHECK -->|call checkAuthorizedRouter| FACTORY
     initializer -->|checks and updates| _initialized
     _disableInitializers -->|updates| _initialized
 
@@ -267,7 +267,7 @@ graph TB
 
 - **initialize**: One-time factory and `principalAccount` initialization for clone instances
 - **receive**: Accepts native token transfers and emits `Received`
-- **executeCalls**: Checks authorization via `factory.isAuthorizedRouter(msg.sender)`, then atomically executes array of contract calls with per-call reporting
+- **executeCalls**: Calls `factory.checkAuthorizedRouter(msg.sender)`, then atomically executes array of contract calls with per-call reporting
 
 ## C4 Level 3: Component Diagrams - RemoteAccountFactory
 
@@ -285,6 +285,7 @@ graph TB
         IRemoteAccountFactory_verifyRemoteAccount[verifyRemoteAccount]
         IRemoteAccountFactory_provideRemoteAccount[provideRemoteAccount]
         IRemoteAccountFactory_isAuthorizedRouter[isAuthorizedRouter]
+        IRemoteAccountFactory_checkAuthorizedRouter[checkAuthorizedRouter]
         %% events
         RemoteAccountCreated@{shape: flag}
     end
@@ -386,6 +387,7 @@ graph TB
         START@{shape: start}
 
         isAuthorizedRouter["isAuthorizedRouter<br>override IRemoteAccountFactory"]
+        checkAuthorizedRouter["checkAuthorizedRouter<br>override IRemoteAccountFactory"]
         getRouterStatus
 
         %% modifiers
@@ -420,6 +422,7 @@ graph TB
 
     %% operation
     START --> isAuthorizedRouter
+    START --> checkAuthorizedRouter
     START --> getRouterStatus
     START --> vetInitialRouter
     START --> vetRouter
@@ -430,6 +433,7 @@ graph TB
     START --> confirmVettingAuthorityTransfer
 
     isAuthorizedRouter -->|reads| _routerStatus
+    checkAuthorizedRouter -->|calls| isAuthorizedRouter
     getRouterStatus -->|reads| _routerStatus
 
     %% EVM-sourced operations (vetting authority)
@@ -471,10 +475,10 @@ graph TB
     confirmVettingAuthorityTransfer -->|"[2] updates"| vettingAuthority
     confirmVettingAuthorityTransfer -->|emit| VettingAuthorityTransferred
 
-    onlyAuthorizedRouter -->|calls| isAuthorizedRouter
+    onlyAuthorizedRouter -->|calls| checkAuthorizedRouter
 
 
-    class isAuthorizedRouter,getRouterStatus,onlyVettingAuthority,onlyAuthorizedRouter readonly
+    class isAuthorizedRouter,checkAuthorizedRouter,getRouterStatus,onlyVettingAuthority,onlyAuthorizedRouter readonly
     class vetInitialRouter,vetRouter,unvetRouter,proposeVettingAuthorityTransfer evm
     class authorizeRouter,deauthorizeRouter,confirmVettingAuthorityTransfer controller
     class _authorizeRouter internal
@@ -492,11 +496,12 @@ graph TB
 - **\_getRemoteAccountAddress**: Rejects the factory principal account (prevents treating factory as a remote account)
 - **\_createRemoteAccount**: Core deterministic clone deployment + factory reference initialization
 - **isAuthorizedRouter**: Checks if a caller is an authorized router
+- **checkAuthorizedRouter**: Reverting authorization check shared by factory modifiers and remote account execution
 
 **Key Components (Router & Vetting Authority Administration)**:
 
 - **onlyVettingAuthority**: Shared modifier enforcing `msg.sender == vettingAuthority` for EVM-side administrative entrypoints
-- **onlyAuthorizedRouter**: Shared modifier enforcing `isAuthorizedRouter(msg.sender)` for Agoric-controlled administrative entrypoints
+- **onlyAuthorizedRouter**: Shared modifier enforcing `checkAuthorizedRouter(msg.sender)` for Agoric-controlled administrative entrypoints
 - **vetInitialRouter**: Vets and authorizes the very first router (vetting authority only, no previous router). This initializes the factory.
 - **vetRouter**: Marks a router as vetted (vetting authority only)
 - **authorizeRouter**: Authorizes a vetted router (authorized router only)
@@ -692,8 +697,7 @@ sequenceDiagram
             Note over PR,RA: make calls
             opt if multiCalls exist
                 PR->>RA: executeCalls(multiCalls)
-                RA->>RAF: isAuthorizedRouter(msg.sender)
-                RAF-->>RA: true
+                RA->>RAF: checkAuthorizedRouter(msg.sender)
                 loop for each {target, data, value, gasLimit}
                     RA->>DEFI: target.call{value, gas: gasLimit}(data)
                     Note over RA,DEFI: gasLimit is optional (0 means no explicit gas)
@@ -730,7 +734,7 @@ sequenceDiagram
         3. RemoteAccountAxelarRouter provides account (creating if necessary)
     - For `processRemoteAccountExecuteInstruction`:
         1. RemoteAccountAxelarRouter provides account (creating if necessary)
-        2. If calls for RemoteAccount exist, RemoteAccountAxelarRouter forwards them; RemoteAccount verifies the caller is an authorized router via the factory, then executes them
+        2. If calls for RemoteAccount exist, RemoteAccountAxelarRouter forwards them; RemoteAccount invokes the factory's shared router authorization check, then executes them
     - For `processAuthorizeRouterInstruction`:
         1. RemoteAccountAxelarRouter verifies the factory principal matches the source address
         2. RemoteAccountAxelarRouter authorizes a vetted router on the factory
@@ -763,7 +767,7 @@ graph TB
 
     RAF ==>|creates & initializes| RA
 
-    RA -.->|isAuthorizedRouter| RAF
+    RA -.->|checkAuthorizedRouter| RAF
 
     style Axelar fill:#ffe6e6
     style VA fill:#ffe6e6
@@ -790,9 +794,10 @@ graph TB
 - **RemoteAccountAxelarRouter admin instructions**: Validate the source address as the factory principal (ensures only the portfolio manager can manage routers or redeem signed permits)
 - **RemoteAccountFactory `provideRemoteAccount`**: Validates remote account address derives from the principal account string
 - **RemoteAccountFactory `onlyVettingAuthority` modifier**: Centralizes `msg.sender == vettingAuthority` enforcement for vetting-authority entrypoints
-- **RemoteAccountFactory `onlyAuthorizedRouter` modifier**: Centralizes `isAuthorizedRouter(msg.sender)` enforcement for router-controlled entrypoints, preventing unauthorized routers from self-authorizing
+- **RemoteAccountFactory `checkAuthorizedRouter`**: Centralizes the reverting authorization check used by router-controlled entrypoints and remote account execution
+- **RemoteAccountFactory `onlyAuthorizedRouter` modifier**: Centralizes `checkAuthorizedRouter(msg.sender)` enforcement for router-controlled entrypoints, preventing unauthorized routers from self-authorizing
 - **RemoteAccountFactory `deauthorizeRouter`**: A router cannot deauthorize itself
-- **RemoteAccount `executeCalls`**: Validates that the caller is an authorized router via `factory.isAuthorizedRouter(msg.sender)`
+- **RemoteAccount `executeCalls`**: Validates that the caller is an authorized router via `factory.checkAuthorizedRouter(msg.sender)`
 
 ## Deployment
 

--- a/packages/axelar-local-dev-cosmos/src/contracts/design.md
+++ b/packages/axelar-local-dev-cosmos/src/contracts/design.md
@@ -73,7 +73,7 @@ graph TB
     LCAn --> AXL
     AXL -->|_execute| PR
     PR -->|provideRemoteAccount| RAF
-    PR -->|"enableRouter |<br>disableRouter |<br>confirmVettingAuthorityTransfer"| RAF
+    PR -->|"authorizeRouter |<br>deauthorizeRouter |<br>confirmVettingAuthorityTransfer"| RAF
     RAF ==>|creates| RA1
     RAF ==>|creates| RA2
     RAF ==>|creates| RAn
@@ -84,7 +84,7 @@ graph TB
     PR -->|executeCalls| RA2
     PR -->|executeCalls| RAn
     PR -.->|permitWitnessTransferFrom| P2
-    VA -->|"vetRouter |<br>revokeRouter |<br>proposeVettingAuthorityTransfer"| RAF
+    VA -->|"vetRouter |<br>unvetRouter |<br>proposeVettingAuthorityTransfer"| RAF
     IMP -->|checks caller| RAF
     IMP -->|call| PROTO
 
@@ -115,7 +115,7 @@ graph TB
         IRemoteAccountRouter_permit2["permit2(): IPermit2"]
         IRemoteAccountRouter_processProvideRemoteAccountInstruction[processProvideRemoteAccountInstruction]
         IRemoteAccountRouter_processRemoteAccountExecuteInstruction[processRemoteAccountExecuteInstruction]
-        IRemoteAccountRouter_adminInstructions["processEnableRouterInstruction<br>processDisableRouterInstruction<br>processConfirmVettingAuthorityInstruction"]
+        IRemoteAccountRouter_adminInstructions["processAuthorizeRouterInstruction<br>processDeauthorizeRouterInstruction<br>processConfirmVettingAuthorityInstruction"]
         %% events
         OperationResult@{shape: flag}
     end
@@ -130,13 +130,13 @@ graph TB
         processProvideRemoteAccountInstruction_self@{shape: comment, label: "require self-call"}
         processRemoteAccountExecuteInstruction["processRemoteAccountExecuteInstruction<br>override IRemoteAccountRouter"]
         processRemoteAccountExecuteInstruction_self@{shape: comment, label: "require self-call"}
-        adminInstructions["processEnableRouterInstruction |<br>processDisableRouterInstruction |<br>processConfirmVettingAuthorityInstruction"]
+        adminInstructions["processAuthorizeRouterInstruction |<br>processDeauthorizeRouterInstruction |<br>processConfirmVettingAuthorityInstruction"]
         adminInstructions_self@{shape: comment, label: "require self-call"}
         VERIFY_FACTORY@{shape: text, label: "verify factory address<br>and principal"}
         DEP@{shape: text, label: "Permit2 Integration"}
         PROV@{shape: text, label: "account creation/<br>verification"}
         MULTI@{shape: text, label: "account use"}
-        ADMIN_CALL@{shape: text, label: "factory admin call<br>(enableRouter |<br>disableRouter |<br>confirmVettingAuthorityTransfer)"}
+        ADMIN_CALL@{shape: text, label: "factory admin call<br>(authorizeRouter |<br>deauthorizeRouter |<br>confirmVettingAuthorityTransfer)"}
         subgraph state
             factory@{shape: stored-data, label: "factory: IRemoteAccountFactory<br>override IRemoteAccountRouter"}
             permit2@{shape: stored-data, label: "permit2: IPermit2<br>override IRemoteAccountRouter"}
@@ -191,7 +191,7 @@ graph TB
 - **\_execute**: Validates source chain, selector, and common decoded payload arguments before dispatching
 - **processProvideRemoteAccountInstruction**: Atomically redeems an optional deposit permit and provisions/verifies a RemoteAccount via the factory
 - **processRemoteAccountExecuteInstruction**: Atomically provisions/verifies a RemoteAccount and executes its multicall batch
-- **processEnableRouterInstruction / processDisableRouterInstruction / processConfirmVettingAuthorityInstruction**: Admin instructions that verify the factory principal, then call the corresponding factory method
+- **processAuthorizeRouterInstruction / processDeauthorizeRouterInstruction / processConfirmVettingAuthorityInstruction**: Admin instructions that verify the factory principal, then call the corresponding factory method
 - **Permit2 Integration**: Transfers tokens to RemoteAccount via Permit2 signature-based transfers
 - **account creation/verification**: Creates or verifies RemoteAccount via factory
 - **account use**: Instructs RemoteAccount to execute arbitrary multicalls
@@ -310,7 +310,7 @@ graph TB
             factoryPrincipalAccount@{shape: stored-data}
             _principalSalt@{shape: stored-data}
             implementation@{shape: stored-data}
-            _routerStatus@{shape: stored-data, label: "_routerStatus: mapping<br>(Unknown | Vetted | Enabled)"}
+            _routerStatus@{shape: stored-data, label: "_routerStatus: mapping<br>(Unknown | Vetted | Authorized)"}
         end
     end
 
@@ -365,14 +365,14 @@ graph TB
 graph TB
     subgraph IRemoteAccountFactory
         IRemoteAccountFactory_isAuthorizedRouter[isAuthorizedRouter]
-        IRemoteAccountFactory_enableRouter[enableRouter]
-        IRemoteAccountFactory_disableRouter[disableRouter]
+        IRemoteAccountFactory_authorizeRouter[authorizeRouter]
+        IRemoteAccountFactory_deauthorizeRouter[deauthorizeRouter]
         IRemoteAccountFactory_confirmVettingAuthorityTransfer[confirmVettingAuthorityTransfer]
         %% events
         RouterVetted@{shape: flag}
-        RouterEnabled@{shape: flag}
-        RouterDisabled@{shape: flag}
-        RouterRevoked@{shape: flag}
+        RouterAuthorized@{shape: flag}
+        RouterDeauthorized@{shape: flag}
+        RouterUnvetted@{shape: flag}
         VettingAuthorityTransferProposed@{shape: flag}
         VettingAuthorityTransferred@{shape: flag}
     end
@@ -387,22 +387,22 @@ graph TB
             CHECK_VA@{shape: text, label: "check msg.sender ==<br>vettingAuthority"}
             vetInitialRouter
             vetRouter
-            revokeRouter
+            unvetRouter
             proposeVettingAuthorityTransfer
         end
 
-        _enableRouter["_enableRouter (internal)"]
+        _authorizeRouter["_authorizeRouter (internal)"]
 
-        subgraph "Agoric-sourced (enabled router)"
+        subgraph "Agoric-sourced (authorized router)"
             CHECK_ROUTER@{shape: text, label: "check isAuthorizedRouter<br>(msg.sender)"}
-            enableRouter["enableRouter<br>override IRemoteAccountFactory"]
-            disableRouter["disableRouter<br>override IRemoteAccountFactory"]
+            authorizeRouter["authorizeRouter<br>override IRemoteAccountFactory"]
+            deauthorizeRouter["deauthorizeRouter<br>override IRemoteAccountFactory"]
             confirmVettingAuthorityTransfer["confirmVettingAuthorityTransfer<br>override IRemoteAccountFactory"]
         end
 
         subgraph state
             numberOfAuthorizedRouters@{shape: stored-data}
-            _routerStatus@{shape: stored-data, label: "_routerStatus: mapping<br>(Unknown | Vetted | Enabled)"}
+            _routerStatus@{shape: stored-data, label: "_routerStatus: mapping<br>(Unknown | Vetted | Authorized)"}
             vettingAuthority@{shape: stored-data}
             _pendingVettingAuthority@{shape: stored-data}
         end
@@ -416,9 +416,9 @@ graph TB
     START --> getRouterStatus
     START --> vetInitialRouter
     START --> vetRouter
-    START --> enableRouter
-    START --> disableRouter
-    START --> revokeRouter
+    START --> authorizeRouter
+    START --> deauthorizeRouter
+    START --> unvetRouter
     START --> proposeVettingAuthorityTransfer
     START --> confirmVettingAuthorityTransfer
 
@@ -428,15 +428,15 @@ graph TB
     %% EVM-sourced operations (vetting authority)
     vetInitialRouter -->|"[1] guard"| numberOfAuthorizedRouters
     vetInitialRouter -->|"[2] calls"| vetRouter
-    vetInitialRouter -->|"[3] calls"| _enableRouter
+    vetInitialRouter -->|"[3] calls"| _authorizeRouter
 
     vetRouter -->|"[1]"| CHECK_VA
     vetRouter -->|"[2] updates"| _routerStatus
     vetRouter -->|emit| RouterVetted
 
-    revokeRouter -->|"[1]"| CHECK_VA
-    revokeRouter -->|"[2] updates"| _routerStatus
-    revokeRouter -->|emit| RouterRevoked
+    unvetRouter -->|"[1]"| CHECK_VA
+    unvetRouter -->|"[2] updates"| _routerStatus
+    unvetRouter -->|emit| RouterUnvetted
 
     proposeVettingAuthorityTransfer -->|"[1]"| CHECK_VA
     proposeVettingAuthorityTransfer -->|"[2] updates"| _pendingVettingAuthority
@@ -444,18 +444,18 @@ graph TB
 
     CHECK_VA -->|checks| vettingAuthority
 
-    %% Agoric-sourced operations (enabled router)
-    enableRouter -->|"[1]"| CHECK_ROUTER
-    enableRouter -->|"[2] calls"| _enableRouter
+    %% Agoric-sourced operations (authorized router)
+    authorizeRouter -->|"[1]"| CHECK_ROUTER
+    authorizeRouter -->|"[2] calls"| _authorizeRouter
 
-    _enableRouter -->|"[1] updates"| _routerStatus
-    _enableRouter -->|"[2] increments"| numberOfAuthorizedRouters
-    _enableRouter -->|emit| RouterEnabled
+    _authorizeRouter -->|"[1] updates"| _routerStatus
+    _authorizeRouter -->|"[2] increments"| numberOfAuthorizedRouters
+    _authorizeRouter -->|emit| RouterAuthorized
 
-    disableRouter -->|"[1]"| CHECK_ROUTER
-    disableRouter -->|"[2] updates"| _routerStatus
-    disableRouter -->|"[3] decrements"| numberOfAuthorizedRouters
-    disableRouter -->|emit| RouterDisabled
+    deauthorizeRouter -->|"[1]"| CHECK_ROUTER
+    deauthorizeRouter -->|"[2] updates"| _routerStatus
+    deauthorizeRouter -->|"[3] decrements"| numberOfAuthorizedRouters
+    deauthorizeRouter -->|emit| RouterDeauthorized
 
     confirmVettingAuthorityTransfer -->|"[1]"| CHECK_ROUTER
     confirmVettingAuthorityTransfer -->|"[2] checks"| _pendingVettingAuthority
@@ -467,10 +467,10 @@ graph TB
     style isAuthorizedRouter fill:#ffe6e6
     style vetInitialRouter fill:#ffe6e6
     style vetRouter fill:#ffe6e6
-    style enableRouter fill:#ffe6e6
-    style _enableRouter fill:#fff0e6
-    style disableRouter fill:#ffe6e6
-    style revokeRouter fill:#ffe6e6
+    style authorizeRouter fill:#ffe6e6
+    style _authorizeRouter fill:#fff0e6
+    style deauthorizeRouter fill:#ffe6e6
+    style unvetRouter fill:#ffe6e6
     style proposeVettingAuthorityTransfer fill:#ffe6e6
     style confirmVettingAuthorityTransfer fill:#ffe6e6
 ```
@@ -483,17 +483,17 @@ graph TB
 - **\_verifyRemoteAccountAddress**: Enforces principal-to-address derivation before creation/verification
 - **\_getRemoteAccountAddress**: Rejects the factory principal account (prevents treating factory as a remote account)
 - **\_createRemoteAccount**: Core deterministic clone deployment + factory reference initialization
-- **isAuthorizedRouter**: Checks if a caller is an enabled router
+- **isAuthorizedRouter**: Checks if a caller is an authorized router
 
 **Key Components (Router & Vetting Authority Administration)**:
 
-- **vetInitialRouter**: Vets and enables the very first router (vetting authority only, no previous router). This initializes the factory.
+- **vetInitialRouter**: Vets and authorizes the very first router (vetting authority only, no previous router). This initializes the factory.
 - **vetRouter**: Marks a router as vetted (vetting authority only)
-- **enableRouter**: Enables a vetted router (enabled router only)
-- **disableRouter**: Disables an enabled router (enabled router only, not self)
-- **revokeRouter**: Revokes a vetted router (vetting authority only)
+- **authorizeRouter**: Authorizes a vetted router (authorized router only)
+- **deauthorizeRouter**: Deauthorizes an authorized router (authorized router only, not self)
+- **unvetRouter**: Unvets a vetted router (vetting authority only)
 - **proposeVettingAuthorityTransfer**: Proposes a new vetting authority (current vetting authority only)
-- **confirmVettingAuthorityTransfer**: Confirms the pending vetting authority transfer (enabled router only)
+- **confirmVettingAuthorityTransfer**: Confirms the pending vetting authority transfer (authorized router only)
 
 ## Data Flow: Factory deployment and initial router setup
 
@@ -522,7 +522,7 @@ sequenceDiagram
     V->>RAF: vetInitialRouter(router)
     RAF->>RAF: require numberOfAuthorizedRouters == 0
     RAF->>RAF: vetRouter(router) — checks vettingAuthority
-    RAF->>RAF: _enableRouter(router)
+    RAF->>RAF: _authorizeRouter(router)
     RAF->>RAF: numberOfAuthorizedRouters = 1
 ```
 
@@ -530,7 +530,7 @@ sequenceDiagram
 
 - The factory constructor does not accept an "initial router" parameter and instead, requires an initialization step (`vetInitialRouter`) from the vetting authority. This avoids creating a circular dependency when constructing the factory and the first router.
 - The vetting authority address is required at construction of the factory. This is to ensure any CREATE2 based deployments cannot be squatted.
-- `vetInitialRouter` is a one-shot bootstrap: it reverts once any router has been authorized (`numberOfAuthorizedRouters > 0`). Subsequent routers follow the normal vet → enable lifecycle via GMP. It's also not possible to revert back to 0 authorized routers.
+- `vetInitialRouter` is a one-shot bootstrap: it reverts once any router has been authorized (`numberOfAuthorizedRouters > 0`). Subsequent routers follow the normal vet → authorize lifecycle via GMP. It's also not possible to revert back to 0 authorized routers.
 
 ## Data Flow: Account creation and use
 
@@ -545,7 +545,7 @@ sequenceDiagram
     participant DEFI as DeFi Protocol
 
     Note right of PM: using portfolio LCA
-    PM->>AXL: send ProvideRemoteAccountInstruction |<br>RemoteAccountExecuteInstruction |<br>EnableRouterInstruction |<br>DisableRouterInstruction |<br>ConfirmVettingAuthorityInstruction
+    PM->>AXL: send ProvideRemoteAccountInstruction |<br>RemoteAccountExecuteInstruction |<br>AuthorizeRouterInstruction |<br>DeauthorizeRouterInstruction |<br>ConfirmVettingAuthorityInstruction
     AXL->>PR: _execute(sourceChain,<br>sourceAddress, payload)
 
     PR->>PR: validate source chain<br>and payload shape
@@ -589,12 +589,12 @@ sequenceDiagram
                     DEFI-->>RA: result
                 end
             end
-        else processEnableRouterInstruction
+        else processAuthorizeRouterInstruction
             PR->>RAF: verifyFactoryPrincipalAccount(sourceAddress)
-            PR->>RAF: enableRouter(instruction.router)
-        else processDisableRouterInstruction
+            PR->>RAF: authorizeRouter(instruction.router)
+        else processDeauthorizeRouterInstruction
             PR->>RAF: verifyFactoryPrincipalAccount(sourceAddress)
-            PR->>RAF: disableRouter(instruction.router)
+            PR->>RAF: deauthorizeRouter(instruction.router)
         else processConfirmVettingAuthorityInstruction
             PR->>RAF: verifyFactoryPrincipalAccount(sourceAddress)
             PR->>RAF: confirmVettingAuthorityTransfer(instruction.authority)
@@ -620,12 +620,12 @@ sequenceDiagram
     - For `processRemoteAccountExecuteInstruction`:
         1. RemoteAccountAxelarRouter provides account (creating if necessary)
         2. If calls for RemoteAccount exist, RemoteAccountAxelarRouter forwards them; RemoteAccount verifies the caller is an authorized router via the factory, then executes them
-    - For `processEnableRouterInstruction`:
+    - For `processAuthorizeRouterInstruction`:
         1. RemoteAccountAxelarRouter verifies the factory principal matches the source address
-        2. RemoteAccountAxelarRouter enables a vetted router on the factory
-    - For `processDisableRouterInstruction`:
+        2. RemoteAccountAxelarRouter authorizes a vetted router on the factory
+    - For `processDeauthorizeRouterInstruction`:
         1. RemoteAccountAxelarRouter verifies the factory principal matches the source address
-        2. RemoteAccountAxelarRouter disables an enabled router on the factory
+        2. RemoteAccountAxelarRouter deauthorizes an authorized router on the factory
     - For `processConfirmVettingAuthorityInstruction`:
         1. RemoteAccountAxelarRouter verifies the factory principal matches the source address
         2. RemoteAccountAxelarRouter confirms the pending vetting authority transfer on the factory
@@ -637,18 +637,18 @@ sequenceDiagram
 graph TB
     Axelar
     VA["Vetting Authority<br/>(EVM multisig)"]
-    ROUTER1[RemoteAccountAxelarRouter v1<br/>enabled]
-    ROUTER2[RemoteAccountAxelarRouter v2<br/>vetted, not yet enabled]
+    ROUTER1[RemoteAccountAxelarRouter v1<br/>authorized]
+    ROUTER2[RemoteAccountAxelarRouter v2<br/>vetted, not yet authorized]
     RAF[RemoteAccountFactory]
     RA[RemoteAccount]
 
     Axelar -->|_execute| ROUTER1
 
-    VA -->|"vetRouter |<br>revokeRouter |<br>proposeVettingAuthorityTransfer"| RAF
+    VA -->|"vetRouter |<br>unvetRouter |<br>proposeVettingAuthorityTransfer"| RAF
 
     ROUTER1 ==>|executeCalls| RA
 
-    ROUTER1 -->|"enableRouter |<br>disableRouter |<br>confirmVettingAuthorityTransfer"| RAF
+    ROUTER1 -->|"authorizeRouter |<br>deauthorizeRouter |<br>confirmVettingAuthorityTransfer"| RAF
 
     RAF ==>|creates & initializes| RA
 
@@ -663,24 +663,24 @@ graph TB
 
 **Transitive Ownership**:
 
-- RemoteAccountFactory maintains a router authorization map with statuses: Unknown, Vetted, Enabled
-- RemoteAccount delegates authorization to its factory: any enabled router can execute calls on any account
-- Router migrations are O(1): enabling a new router instantly authorizes it for all accounts
+- RemoteAccountFactory maintains a router authorization map with statuses: Unknown, Vetted, Authorized
+- RemoteAccount delegates authorization to its factory: any authorized router can execute calls on any account
+- Router migrations are O(1): authorizing a new router instantly authorizes it for all accounts
 
 **Two-Factor Router Authorization**:
 
-- **Vetting** (EVM-side): The factory's vetting authority (e.g. multisig) can vet or revoke routers via direct calls
-- **Enabling** (Agoric-side): The factory's principal can enable or disable vetted routers via GMP messages through an enabled router
-- A router must be both vetted and enabled to operate on remote accounts
+- **Vetting** (EVM-side): The factory's vetting authority (e.g. multisig) can vet or unvet routers via direct calls
+- **Authorization** (Agoric-side): The factory's principal can authorize or deauthorize vetted routers via GMP messages through an authorized router
+- A router must be both vetted and authorized to operate on remote accounts
 
 **Security Checks**:
 
 - **RemoteAccountAxelarRouter `_execute`**: Validate `sourceChain` against immutable hash
 - **RemoteAccountAxelarRouter admin instructions**: Validate the source address as the factory principal (ensures only the portfolio manager can manage routers or redeem signed permits)
 - **RemoteAccountFactory `provideRemoteAccount`**: Validates remote account address derives from the principal account string
-- **RemoteAccountFactory `vetRouter`/`revokeRouter`**: Only the vetting authority can call these
-- **RemoteAccountFactory `enableRouter`/`disableRouter`**: Only an already-enabled router can call these (preventing unauthorized routers from self-enabling)
-- **RemoteAccountFactory `disableRouter`**: A router cannot disable itself
+- **RemoteAccountFactory `vetRouter`/`unvetRouter`**: Only the vetting authority can call these
+- **RemoteAccountFactory `authorizeRouter`/`deauthorizeRouter`**: Only an already-authorized router can call these (preventing unauthorized routers from self-authorizing)
+- **RemoteAccountFactory `deauthorizeRouter`**: A router cannot deauthorize itself
 - **RemoteAccount `executeCalls`**: Validates that the caller is an authorized router via `factory.isAuthorizedRouter(msg.sender)`
 
 ## Deployment
@@ -715,9 +715,9 @@ sequenceDiagram
     EVM_DEPLOYER->>ROUTERn: deploy(gateway, sourceChain, factory=RAF, permit2)
     VA->>RAF: vetRouter(ROUTERn)
 
-    Note over PM,RA: Enable new router (via GMP)
-    PM->>ROUTER1: [via Axelar] processEnableRouterInstruction(ROUTERn)
-    ROUTER1->>RAF: enableRouter(ROUTERn)
+    Note over PM,RA: Authorize new router (via GMP)
+    PM->>ROUTER1: [via Axelar] processAuthorizeRouterInstruction(ROUTERn)
+    ROUTER1->>RAF: authorizeRouter(ROUTERn)
 
     Note over PM,RA: Both routers now operational
     PM->>ROUTERn: [via Axelar] processRemoteAccountExecuteInstruction
@@ -725,14 +725,14 @@ sequenceDiagram
     RAF-->>RA: create/validate
     ROUTERn->>RA: executeCalls
 
-    Note over PM,RA: Optionally disable old router (via GMP)
-    PM->>ROUTERn: [via Axelar] processDisableRouterInstruction(ROUTER1)
-    ROUTERn->>RAF: disableRouter(ROUTER1)
+    Note over PM,RA: Optionally deauthorize old router (via GMP)
+    PM->>ROUTERn: [via Axelar] processDeauthorizeRouterInstruction(ROUTER1)
+    ROUTERn->>RAF: deauthorizeRouter(ROUTER1)
 ```
 
 **Migration Features**:
 
-- **O(1) migration**: Enabling a new router instantly authorizes it for all existing accounts — no per-account ownership transfer needed
+- **O(1) migration**: Authorizing a new router instantly authorizes it for all existing accounts — no per-account ownership transfer needed
 - **Non-disruptive**: Old and new routers can coexist during migration
 - **Two-factor safety**: Router changes require agreement from both the vetting authority (EVM) and the factory principal (Agoric)
 - **Flexible**: RemoteAccount addresses remain constant across router upgrades

--- a/packages/axelar-local-dev-cosmos/src/contracts/interfaces/IRemoteAccount.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/interfaces/IRemoteAccount.sol
@@ -36,7 +36,5 @@ interface IRemoteAccount {
 
     function factory() external view returns (address);
 
-    function principalAccount() external view returns (string memory);
-
     function executeCalls(ContractCall[] calldata calls) external payable;
 }

--- a/packages/axelar-local-dev-cosmos/src/contracts/interfaces/IRemoteAccount.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/interfaces/IRemoteAccount.sol
@@ -33,7 +33,6 @@ interface IRemoteAccount {
     );
 
     error ContractCallFailed(address target, bytes4 selector, uint32 callIndex, bytes reason);
-    error UnauthorizedCaller(address caller);
 
     function factory() external view returns (address);
 

--- a/packages/axelar-local-dev-cosmos/src/contracts/interfaces/IRemoteAccount.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/interfaces/IRemoteAccount.sol
@@ -37,5 +37,7 @@ interface IRemoteAccount {
 
     function factory() external view returns (address);
 
+    function principalAccount() external view returns (string memory);
+
     function executeCalls(ContractCall[] calldata calls) external payable;
 }

--- a/packages/axelar-local-dev-cosmos/src/contracts/interfaces/IRemoteAccount.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/interfaces/IRemoteAccount.sol
@@ -33,6 +33,9 @@ interface IRemoteAccount {
     );
 
     error ContractCallFailed(address target, bytes4 selector, uint32 callIndex, bytes reason);
+    error UnauthorizedCaller(address caller);
+
+    function factory() external view returns (address);
 
     function executeCalls(ContractCall[] calldata calls) external payable;
 }

--- a/packages/axelar-local-dev-cosmos/src/contracts/interfaces/IRemoteAccountFactory.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/interfaces/IRemoteAccountFactory.sol
@@ -11,8 +11,8 @@ interface IRemoteAccountFactory {
 
     event RemoteAccountCreated(address indexed accountAddress, string principalAccount);
 
-    event RouterEnabled(address indexed router, uint256 numberOfAuthorizedRouters);
-    event RouterDisabled(address indexed router, uint256 numberOfAuthorizedRouters);
+    event RouterAuthorized(address indexed router, uint256 numberOfAuthorizedRouters);
+    event RouterDeauthorized(address indexed router, uint256 numberOfAuthorizedRouters);
 
     function factoryPrincipalCaip2() external view returns (string memory);
 
@@ -38,9 +38,9 @@ interface IRemoteAccountFactory {
 
     function numberOfAuthorizedRouters() external view returns (uint256);
 
-    function enableRouter(address router) external;
+    function authorizeRouter(address router) external;
 
-    function disableRouter(address router) external;
+    function deauthorizeRouter(address router) external;
 
     function confirmVettingAuthorityTransfer(address newVettingAuthority) external;
 }

--- a/packages/axelar-local-dev-cosmos/src/contracts/interfaces/IRemoteAccountFactory.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/interfaces/IRemoteAccountFactory.sol
@@ -2,12 +2,20 @@
 pragma solidity ^0.8.20;
 
 interface IRemoteAccountFactory {
+    enum RouterStatus {
+        Unknown, // Could be potentially revoked
+        Vetted,
+        Enabled
+    }
+
     error AddressMismatch(address expected, address actual);
     error InvalidAccountAtAddress(address account);
     error PrincipalAccountMismatch(string expected, string actual);
     error RouterNotVetted(address router);
-    error RouterStillEnabled(address router);
+    error RouterNotEnabled(address router);
     error UnauthorizedCaller(address caller);
+
+    error InvalidVettingAuthority(address requested, address expected);
 
     event RemoteAccountCreated(address indexed accountAddress, string principalAccount);
 
@@ -15,6 +23,11 @@ interface IRemoteAccountFactory {
     event RouterEnabled(address indexed router);
     event RouterDisabled(address indexed router);
     event RouterRevoked(address indexed router);
+
+    event VettingAuthorityTransferred(
+        address indexed previousVettingAuthority,
+        address indexed newVettingAuthority
+    );
 
     function factoryPrincipalCaip2() external view returns (string memory);
 
@@ -36,13 +49,13 @@ interface IRemoteAccountFactory {
         address expectedAddress
     ) external returns (bool created);
 
-    function isAuthorizedCaller(address caller) external view returns (bool);
+    function isAuthorizedRouter(address caller) external view returns (bool);
 
-    function vetRouter(address router) external;
+    function getRouterStatus(address router) external view returns (RouterStatus);
 
     function enableRouter(address router) external;
 
     function disableRouter(address router) external;
 
-    function revokeRouter(address router) external;
+    function confirmVettingAuthorityTransfer(address newVettingAuthority) external;
 }

--- a/packages/axelar-local-dev-cosmos/src/contracts/interfaces/IRemoteAccountFactory.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/interfaces/IRemoteAccountFactory.sol
@@ -20,8 +20,8 @@ interface IRemoteAccountFactory {
     event RemoteAccountCreated(address indexed accountAddress, string principalAccount);
 
     event RouterVetted(address indexed router);
-    event RouterEnabled(address indexed router);
-    event RouterDisabled(address indexed router);
+    event RouterEnabled(address indexed router, uint256 numberOfAuthorizedRouters);
+    event RouterDisabled(address indexed router, uint256 numberOfAuthorizedRouters);
     event RouterRevoked(address indexed router);
 
     event VettingAuthorityTransferProposed(
@@ -57,6 +57,8 @@ interface IRemoteAccountFactory {
     function isAuthorizedRouter(address caller) external view returns (bool);
 
     function getRouterStatus(address router) external view returns (RouterStatus);
+
+    function numberOfAuthorizedRouters() external view returns (uint256);
 
     function enableRouter(address router) external;
 

--- a/packages/axelar-local-dev-cosmos/src/contracts/interfaces/IRemoteAccountFactory.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/interfaces/IRemoteAccountFactory.sol
@@ -36,6 +36,8 @@ interface IRemoteAccountFactory {
 
     function isAuthorizedRouter(address caller) external view returns (bool);
 
+    function checkAuthorizedRouter(address caller) external view;
+
     function numberOfAuthorizedRouters() external view returns (uint256);
 
     function authorizeRouter(address router) external;

--- a/packages/axelar-local-dev-cosmos/src/contracts/interfaces/IRemoteAccountFactory.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/interfaces/IRemoteAccountFactory.sol
@@ -3,15 +3,18 @@ pragma solidity ^0.8.20;
 
 interface IRemoteAccountFactory {
     error AddressMismatch(address expected, address actual);
-    error UnauthorizedOwner(address owner, address account);
     error InvalidAccountAtAddress(address account);
     error PrincipalAccountMismatch(string expected, string actual);
+    error RouterNotVetted(address router);
+    error RouterStillEnabled(address router);
+    error UnauthorizedCaller(address caller);
 
-    event RemoteAccountCreated(
-        address indexed accountAddress,
-        string principalAccount,
-        address indexed ownerAddress
-    );
+    event RemoteAccountCreated(address indexed accountAddress, string principalAccount);
+
+    event RouterVetted(address indexed router);
+    event RouterEnabled(address indexed router);
+    event RouterDisabled(address indexed router);
+    event RouterRevoked(address indexed router);
 
     function factoryPrincipalCaip2() external view returns (string memory);
 
@@ -25,19 +28,21 @@ interface IRemoteAccountFactory {
 
     function verifyRemoteAccount(
         string calldata principalAccount,
-        address expectedOwner,
         address accountAddress
     ) external view;
 
     function provideRemoteAccount(
         string calldata principalAccount,
-        address expectedOwner,
         address expectedAddress
     ) external returns (bool created);
 
-    function provideRemoteAccountForOwner(
-        string calldata principalAccount,
-        address owner,
-        address expectedAddress
-    ) external returns (bool created);
+    function isAuthorizedCaller(address caller) external view returns (bool);
+
+    function vetRouter(address router) external;
+
+    function enableRouter(address router) external;
+
+    function disableRouter(address router) external;
+
+    function revokeRouter(address router) external;
 }

--- a/packages/axelar-local-dev-cosmos/src/contracts/interfaces/IRemoteAccountFactory.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/interfaces/IRemoteAccountFactory.sol
@@ -24,6 +24,11 @@ interface IRemoteAccountFactory {
     event RouterDisabled(address indexed router);
     event RouterRevoked(address indexed router);
 
+    event VettingAuthorityTransferProposed(
+        address indexed currentVettingAuthority,
+        address indexed proposedVettingAuthority
+    );
+
     event VettingAuthorityTransferred(
         address indexed previousVettingAuthority,
         address indexed newVettingAuthority

--- a/packages/axelar-local-dev-cosmos/src/contracts/interfaces/IRemoteAccountFactory.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/interfaces/IRemoteAccountFactory.sol
@@ -2,37 +2,17 @@
 pragma solidity ^0.8.20;
 
 interface IRemoteAccountFactory {
-    enum RouterStatus {
-        Unknown, // Could be potentially revoked
-        Vetted,
-        Enabled
-    }
-
     error AddressMismatch(address expected, address actual);
     error InvalidAccountAtAddress(address account);
     error PrincipalAccountMismatch(string expected, string actual);
-    error RouterNotVetted(address router);
-    error RouterNotEnabled(address router);
     error UnauthorizedCaller(address caller);
 
     error InvalidVettingAuthority(address requested, address expected);
 
     event RemoteAccountCreated(address indexed accountAddress, string principalAccount);
 
-    event RouterVetted(address indexed router);
     event RouterEnabled(address indexed router, uint256 numberOfAuthorizedRouters);
     event RouterDisabled(address indexed router, uint256 numberOfAuthorizedRouters);
-    event RouterRevoked(address indexed router);
-
-    event VettingAuthorityTransferProposed(
-        address indexed currentVettingAuthority,
-        address indexed proposedVettingAuthority
-    );
-
-    event VettingAuthorityTransferred(
-        address indexed previousVettingAuthority,
-        address indexed newVettingAuthority
-    );
 
     function factoryPrincipalCaip2() external view returns (string memory);
 
@@ -55,8 +35,6 @@ interface IRemoteAccountFactory {
     ) external returns (bool created);
 
     function isAuthorizedRouter(address caller) external view returns (bool);
-
-    function getRouterStatus(address router) external view returns (RouterStatus);
 
     function numberOfAuthorizedRouters() external view returns (uint256);
 

--- a/packages/axelar-local-dev-cosmos/src/contracts/interfaces/IRemoteAccountRouter.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/interfaces/IRemoteAccountRouter.sol
@@ -34,6 +34,14 @@ struct UpdateOwnerInstruction {
     address newOwner;
 }
 
+struct EnableRouterInstruction {
+    address router;
+}
+
+struct DisableRouterInstruction {
+    address router;
+}
+
 interface IRemoteAccountRouter {
     event OperationResult(
         string indexed txId,
@@ -45,7 +53,8 @@ interface IRemoteAccountRouter {
         bytes reason
     );
 
-    event SuccessorSet(address indexed previousSuccessor, address indexed newSuccessor);
+    event RouterVetted(address indexed router);
+    event RouterRevoked(address indexed router);
 
     error SubcallOutOfGas();
     error InvalidInstructionSelector(bytes4 selector);
@@ -53,8 +62,6 @@ interface IRemoteAccountRouter {
     function factory() external view returns (IRemoteAccountFactory);
 
     function permit2() external view returns (IPermit2);
-
-    function successor() external view returns (address);
 
     function processProvideRemoteAccountInstruction(
         string calldata sourceAddress,
@@ -70,7 +77,19 @@ interface IRemoteAccountRouter {
 
     function processUpdateOwnerInstruction(
         string calldata sourceAddress,
-        address expectedAccountAddress,
+        address factoryAddress,
         UpdateOwnerInstruction calldata instruction
+    ) external;
+
+    function processEnableRouterInstruction(
+        string calldata sourceAddress,
+        address factoryAddress,
+        EnableRouterInstruction calldata instruction
+    ) external;
+
+    function processDisableRouterInstruction(
+        string calldata sourceAddress,
+        address factoryAddress,
+        DisableRouterInstruction calldata instruction
     ) external;
 }

--- a/packages/axelar-local-dev-cosmos/src/contracts/interfaces/IRemoteAccountRouter.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/interfaces/IRemoteAccountRouter.sol
@@ -30,16 +30,16 @@ struct RemoteAccountExecuteInstruction {
     ContractCall[] multiCalls;
 }
 
-struct UpdateOwnerInstruction {
-    address newOwner;
-}
-
 struct EnableRouterInstruction {
     address router;
 }
 
 struct DisableRouterInstruction {
     address router;
+}
+
+struct ConfirmVettingAuthorityInstruction {
+    address authority;
 }
 
 interface IRemoteAccountRouter {
@@ -52,9 +52,6 @@ interface IRemoteAccountRouter {
         bool success,
         bytes reason
     );
-
-    event RouterVetted(address indexed router);
-    event RouterRevoked(address indexed router);
 
     error SubcallOutOfGas();
     error InvalidInstructionSelector(bytes4 selector);
@@ -75,12 +72,6 @@ interface IRemoteAccountRouter {
         RemoteAccountExecuteInstruction calldata instruction
     ) external;
 
-    function processUpdateOwnerInstruction(
-        string calldata sourceAddress,
-        address factoryAddress,
-        UpdateOwnerInstruction calldata instruction
-    ) external;
-
     function processEnableRouterInstruction(
         string calldata sourceAddress,
         address factoryAddress,
@@ -91,5 +82,11 @@ interface IRemoteAccountRouter {
         string calldata sourceAddress,
         address factoryAddress,
         DisableRouterInstruction calldata instruction
+    ) external;
+
+    function processConfirmVettingAuthorityInstruction(
+        string calldata sourceAddress,
+        address factoryAddress,
+        ConfirmVettingAuthorityInstruction calldata instruction
     ) external;
 }

--- a/packages/axelar-local-dev-cosmos/src/contracts/interfaces/IRemoteAccountRouter.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/interfaces/IRemoteAccountRouter.sol
@@ -30,11 +30,11 @@ struct RemoteAccountExecuteInstruction {
     ContractCall[] multiCalls;
 }
 
-struct EnableRouterInstruction {
+struct AuthorizeRouterInstruction {
     address router;
 }
 
-struct DisableRouterInstruction {
+struct DeauthorizeRouterInstruction {
     address router;
 }
 
@@ -72,16 +72,16 @@ interface IRemoteAccountRouter {
         RemoteAccountExecuteInstruction calldata instruction
     ) external;
 
-    function processEnableRouterInstruction(
+    function processAuthorizeRouterInstruction(
         string calldata sourceAddress,
         address factoryAddress,
-        EnableRouterInstruction calldata instruction
+        AuthorizeRouterInstruction calldata instruction
     ) external;
 
-    function processDisableRouterInstruction(
+    function processDeauthorizeRouterInstruction(
         string calldata sourceAddress,
         address factoryAddress,
-        DisableRouterInstruction calldata instruction
+        DeauthorizeRouterInstruction calldata instruction
     ) external;
 
     function processConfirmVettingAuthorityInstruction(

--- a/packages/axelar-local-dev-cosmos/src/contracts/interfaces/IRemoteAccountRouter.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/interfaces/IRemoteAccountRouter.sol
@@ -46,7 +46,7 @@ interface IRemoteAccountRouter {
     event OperationResult(
         string indexed txId,
         string indexed sourceAddressIndex,
-        string sourceAddress,
+        string txIdPlaintext,
         address indexed allegedRemoteAccount,
         bytes4 instructionSelector,
         bool success,

--- a/packages/axelar-local-dev-cosmos/src/interfaces/router.ts
+++ b/packages/axelar-local-dev-cosmos/src/interfaces/router.ts
@@ -81,17 +81,6 @@ export type RemoteAccountExecuteInstruction = AbiParameterToPrimitiveType<{
     components: typeof RemoteAccountExecuteInstructionComponents;
 }>;
 
-export const updateOwnerInstructionComponents = [
-    {
-        name: 'newOwner',
-        type: 'address',
-    },
-] as const satisfies AbiParameter[];
-export type UpdateOwnerInstruction = AbiParameterToPrimitiveType<{
-    type: 'tuple';
-    components: typeof updateOwnerInstructionComponents;
-}>;
-
 export const enableRouterInstructionComponents = [
     {
         name: 'router',
@@ -112,6 +101,17 @@ export const disableRouterInstructionComponents = [
 export type DisableRouterInstruction = AbiParameterToPrimitiveType<{
     type: 'tuple';
     components: typeof disableRouterInstructionComponents;
+}>;
+
+export const confirmVettingAuthorityInstructionComponents = [
+    {
+        name: 'authority',
+        type: 'address',
+    },
+] as const satisfies AbiParameter[];
+export type ConfirmVettingAuthorityInstruction = AbiParameterToPrimitiveType<{
+    type: 'tuple';
+    components: typeof confirmVettingAuthorityInstructionComponents;
 }>;
 
 /**
@@ -135,15 +135,6 @@ export const processRemoteAccountExecuteInstructionInputs = [
     },
 ] as const satisfies AbiParameter[];
 
-export const processUpdateOwnerInstructionInputs = [
-    ...routerProcessSharedInputComponents,
-    {
-        name: 'instruction',
-        type: 'tuple',
-        components: updateOwnerInstructionComponents,
-    },
-] as const satisfies AbiParameter[];
-
 export const processEnableRouterInstructionInputs = [
     ...routerProcessSharedInputComponents,
     {
@@ -159,6 +150,15 @@ export const processDisableRouterInstructionInputs = [
         name: 'instruction',
         type: 'tuple',
         components: disableRouterInstructionComponents,
+    },
+] as const satisfies AbiParameter[];
+
+export const processConfirmVettingAuthorityInstructionInputs = [
+    ...routerProcessSharedInputComponents,
+    {
+        name: 'instruction',
+        type: 'tuple',
+        components: confirmVettingAuthorityInstructionComponents,
     },
 ] as const satisfies AbiParameter[];
 
@@ -208,13 +208,6 @@ export const remoteAccountAxelarRouterABI = [
     },
     {
         type: 'function',
-        name: 'processUpdateOwnerInstruction',
-        inputs: processUpdateOwnerInstructionInputs,
-        outputs: [],
-        stateMutability: 'nonpayable',
-    },
-    {
-        type: 'function',
         name: 'processEnableRouterInstruction',
         inputs: processEnableRouterInstructionInputs,
         outputs: [],
@@ -224,6 +217,13 @@ export const remoteAccountAxelarRouterABI = [
         type: 'function',
         name: 'processDisableRouterInstruction',
         inputs: processDisableRouterInstructionInputs,
+        outputs: [],
+        stateMutability: 'nonpayable',
+    },
+    {
+        type: 'function',
+        name: 'processConfirmVettingAuthorityInstruction',
+        inputs: processConfirmVettingAuthorityInstructionInputs,
         outputs: [],
         stateMutability: 'nonpayable',
     },
@@ -297,7 +297,7 @@ export const remoteAccountFactoryABI = [
     },
     {
         type: 'function',
-        name: 'isAuthorizedCaller',
+        name: 'isAuthorizedRouter',
         inputs: [{ name: 'caller', type: 'address' }],
         outputs: [{ name: '', type: 'bool' }],
         stateMutability: 'view',

--- a/packages/axelar-local-dev-cosmos/src/interfaces/router.ts
+++ b/packages/axelar-local-dev-cosmos/src/interfaces/router.ts
@@ -81,26 +81,26 @@ export type RemoteAccountExecuteInstruction = AbiParameterToPrimitiveType<{
     components: typeof RemoteAccountExecuteInstructionComponents;
 }>;
 
-export const enableRouterInstructionComponents = [
+export const authorizeRouterInstructionComponents = [
     {
         name: 'router',
         type: 'address',
     },
 ] as const satisfies AbiParameter[];
-export type EnableRouterInstruction = AbiParameterToPrimitiveType<{
+export type AuthorizeRouterInstruction = AbiParameterToPrimitiveType<{
     type: 'tuple';
-    components: typeof enableRouterInstructionComponents;
+    components: typeof authorizeRouterInstructionComponents;
 }>;
 
-export const disableRouterInstructionComponents = [
+export const deauthorizeRouterInstructionComponents = [
     {
         name: 'router',
         type: 'address',
     },
 ] as const satisfies AbiParameter[];
-export type DisableRouterInstruction = AbiParameterToPrimitiveType<{
+export type DeauthorizeRouterInstruction = AbiParameterToPrimitiveType<{
     type: 'tuple';
-    components: typeof disableRouterInstructionComponents;
+    components: typeof deauthorizeRouterInstructionComponents;
 }>;
 
 export const confirmVettingAuthorityInstructionComponents = [
@@ -135,21 +135,21 @@ export const processRemoteAccountExecuteInstructionInputs = [
     },
 ] as const satisfies AbiParameter[];
 
-export const processEnableRouterInstructionInputs = [
+export const processAuthorizeRouterInstructionInputs = [
     ...routerProcessSharedInputComponents,
     {
         name: 'instruction',
         type: 'tuple',
-        components: enableRouterInstructionComponents,
+        components: authorizeRouterInstructionComponents,
     },
 ] as const satisfies AbiParameter[];
 
-export const processDisableRouterInstructionInputs = [
+export const processDeauthorizeRouterInstructionInputs = [
     ...routerProcessSharedInputComponents,
     {
         name: 'instruction',
         type: 'tuple',
-        components: disableRouterInstructionComponents,
+        components: deauthorizeRouterInstructionComponents,
     },
 ] as const satisfies AbiParameter[];
 
@@ -208,15 +208,15 @@ export const remoteAccountAxelarRouterABI = [
     },
     {
         type: 'function',
-        name: 'processEnableRouterInstruction',
-        inputs: processEnableRouterInstructionInputs,
+        name: 'processAuthorizeRouterInstruction',
+        inputs: processAuthorizeRouterInstructionInputs,
         outputs: [],
         stateMutability: 'nonpayable',
     },
     {
         type: 'function',
-        name: 'processDisableRouterInstruction',
-        inputs: processDisableRouterInstructionInputs,
+        name: 'processDeauthorizeRouterInstruction',
+        inputs: processDeauthorizeRouterInstructionInputs,
         outputs: [],
         stateMutability: 'nonpayable',
     },

--- a/packages/axelar-local-dev-cosmos/src/interfaces/router.ts
+++ b/packages/axelar-local-dev-cosmos/src/interfaces/router.ts
@@ -92,6 +92,28 @@ export type UpdateOwnerInstruction = AbiParameterToPrimitiveType<{
     components: typeof updateOwnerInstructionComponents;
 }>;
 
+export const enableRouterInstructionComponents = [
+    {
+        name: 'router',
+        type: 'address',
+    },
+] as const satisfies AbiParameter[];
+export type EnableRouterInstruction = AbiParameterToPrimitiveType<{
+    type: 'tuple';
+    components: typeof enableRouterInstructionComponents;
+}>;
+
+export const disableRouterInstructionComponents = [
+    {
+        name: 'router',
+        type: 'address',
+    },
+] as const satisfies AbiParameter[];
+export type DisableRouterInstruction = AbiParameterToPrimitiveType<{
+    type: 'tuple';
+    components: typeof disableRouterInstructionComponents;
+}>;
+
 /**
  * ABI inputs for encoding RouterPayload with encodeAbiParameters.
  */
@@ -119,6 +141,24 @@ export const processUpdateOwnerInstructionInputs = [
         name: 'instruction',
         type: 'tuple',
         components: updateOwnerInstructionComponents,
+    },
+] as const satisfies AbiParameter[];
+
+export const processEnableRouterInstructionInputs = [
+    ...routerProcessSharedInputComponents,
+    {
+        name: 'instruction',
+        type: 'tuple',
+        components: enableRouterInstructionComponents,
+    },
+] as const satisfies AbiParameter[];
+
+export const processDisableRouterInstructionInputs = [
+    ...routerProcessSharedInputComponents,
+    {
+        name: 'instruction',
+        type: 'tuple',
+        components: disableRouterInstructionComponents,
     },
 ] as const satisfies AbiParameter[];
 
@@ -170,6 +210,20 @@ export const remoteAccountAxelarRouterABI = [
         type: 'function',
         name: 'processUpdateOwnerInstruction',
         inputs: processUpdateOwnerInstructionInputs,
+        outputs: [],
+        stateMutability: 'nonpayable',
+    },
+    {
+        type: 'function',
+        name: 'processEnableRouterInstruction',
+        inputs: processEnableRouterInstructionInputs,
+        outputs: [],
+        stateMutability: 'nonpayable',
+    },
+    {
+        type: 'function',
+        name: 'processDisableRouterInstruction',
+        inputs: processDisableRouterInstructionInputs,
         outputs: [],
         stateMutability: 'nonpayable',
     },
@@ -236,7 +290,6 @@ export const remoteAccountFactoryABI = [
         name: 'provideRemoteAccount',
         inputs: [
             { name: 'principalAccount', type: 'string' },
-            { name: 'expectedOwner', type: 'address' },
             { name: 'expectedAddress', type: 'address' },
         ],
         outputs: [{ name: '', type: 'bool' }],
@@ -244,13 +297,9 @@ export const remoteAccountFactoryABI = [
     },
     {
         type: 'function',
-        name: 'provideRemoteAccountForOwner',
-        inputs: [
-            { name: 'principalAccount', type: 'string' },
-            { name: 'owner', type: 'address' },
-            { name: 'expectedAddress', type: 'address' },
-        ],
+        name: 'isAuthorizedCaller',
+        inputs: [{ name: 'caller', type: 'address' }],
         outputs: [{ name: '', type: 'bool' }],
-        stateMutability: 'nonpayable',
+        stateMutability: 'view',
     },
 ] as const satisfies Abi;


### PR DESCRIPTION
refs:
- https://linear.app/agoric/issue/PAK-155/redesign-router-migration-around-vetted-factory-owned-routers

## Description
- Replace per-account `Ownable` ownership with factory-delegated authorization via `isAuthorizedCaller()`, enabling O(1) router migration by managing router authorization in the deploying factory.
- Add two-factor router authorization: vetting (`vetRouter`/`revokeRouter`) + enabling via Agoric GMP(`enableRouter`/`disableRouter`).
- Add dedicated tests for changes introduced.