### PR TITLE
chore: scripts for manual vettting and contract verification

### DIFF
--- a/integration/chain-config.ts
+++ b/integration/chain-config.ts
@@ -9,7 +9,20 @@ export interface ChainConfig {
   rpcUrl: string;
   chainId: number;
   nativeToken: string;
+  /** Axelar Gateway contract address */
+  gateway: string;
+  /** Axelar Gas Service contract address */
+  gasService: string;
+  /** Uniswap Permit2 contract address */
+  permit2: string;
+  /** Hardhat network name (used for --network flag) */
+  hardhatNetwork: string;
 }
+
+// Sources:
+// Axelar mainnet: https://docs.axelar.dev/dev/reference/mainnet-contract-addresses/
+// Axelar testnet: https://docs.axelar.dev/dev/reference/testnet-contract-addresses/
+// Permit2: https://docs.uniswap.org/contracts/v4/deployments
 
 export const MAINNET_CHAINS: ChainConfig[] = [
   {
@@ -17,30 +30,50 @@ export const MAINNET_CHAINS: ChainConfig[] = [
     rpcUrl: `https://mainnet.infura.io/v3/${INFURA_KEY}`,
     chainId: 1,
     nativeToken: "ETH",
+    gateway: "0x4F4495243837681061C4743b74B3eEdf548D56A5",
+    gasService: "0x2d5d7d31F671F86C782533cc367F14109a082712",
+    permit2: "0x000000000022D473030F116dDEE9F6B43aC78BA3",
+    hardhatNetwork: "eth",
   },
   {
     name: "Base",
     rpcUrl: "https://mainnet.base.org",
     chainId: 8453,
     nativeToken: "ETH",
+    gateway: "0xe432150cce91c13a887f7D836923d5597adD8E31",
+    gasService: "0x2d5d7d31F671F86C782533cc367F14109a082712",
+    permit2: "0x000000000022D473030F116dDEE9F6B43aC78BA3",
+    hardhatNetwork: "base",
   },
   {
     name: "Avalanche",
     rpcUrl: "https://api.avax.network/ext/bc/C/rpc",
     chainId: 43114,
     nativeToken: "AVAX",
+    gateway: "0x5029C0EFf6C34351a0CEc334542cDb22c7928f78",
+    gasService: "0x2d5d7d31F671F86C782533cc367F14109a082712",
+    permit2: "0x000000000022D473030F116dDEE9F6B43aC78BA3",
+    hardhatNetwork: "avax",
   },
   {
     name: "Arbitrum",
     rpcUrl: "https://arb1.arbitrum.io/rpc",
     chainId: 42161,
     nativeToken: "ETH",
+    gateway: "0xe432150cce91c13a887f7D836923d5597adD8E31",
+    gasService: "0x2d5d7d31F671F86C782533cc367F14109a082712",
+    permit2: "0x000000000022D473030F116dDEE9F6B43aC78BA3",
+    hardhatNetwork: "arb",
   },
   {
     name: "Optimism",
     rpcUrl: "https://mainnet.optimism.io",
     chainId: 10,
     nativeToken: "ETH",
+    gateway: "0xe432150cce91c13a887f7D836923d5597adD8E31",
+    gasService: "0x2d5d7d31F671F86C782533cc367F14109a082712",
+    permit2: "0x000000000022D473030F116dDEE9F6B43aC78BA3",
+    hardhatNetwork: "opt",
   },
 ];
 
@@ -50,30 +83,50 @@ export const TESTNET_CHAINS: ChainConfig[] = [
     rpcUrl: "https://ethereum-sepolia-rpc.publicnode.com",
     chainId: 11155111,
     nativeToken: "ETH",
+    gateway: "0xe432150cce91c13a887f7D836923d5597adD8E31",
+    gasService: "0xbE406F0189A0B4cf3A05C286473D23791Dd44Cc6",
+    permit2: "0x000000000022D473030F116dDEE9F6B43aC78BA3",
+    hardhatNetwork: "eth-sepolia",
   },
   {
     name: "Base Sepolia",
     rpcUrl: "https://sepolia.base.org",
     chainId: 84532,
     nativeToken: "ETH",
+    gateway: "0xe432150cce91c13a887f7D836923d5597adD8E31",
+    gasService: "0xbE406F0189A0B4cf3A05C286473D23791Dd44Cc6",
+    permit2: "0x000000000022D473030F116dDEE9F6B43aC78BA3",
+    hardhatNetwork: "base-sepolia",
   },
   {
     name: "Fuji",
     rpcUrl: "https://api.avax-test.network/ext/bc/C/rpc",
     chainId: 43113,
     nativeToken: "AVAX",
+    gateway: "0xC249632c2D40b9001FE907806902f63038B737Ab",
+    gasService: "0xbE406F0189A0B4cf3A05C286473D23791Dd44Cc6",
+    permit2: "",
+    hardhatNetwork: "fuji",
   },
   {
     name: "Arb Sepolia",
     rpcUrl: "https://sepolia-rollup.arbitrum.io/rpc",
     chainId: 421614,
     nativeToken: "ETH",
+    gateway: "0xe1cE95479C84e9809269227C7F8524aE051Ae77a",
+    gasService: "0xbE406F0189A0B4cf3A05C286473D23791Dd44Cc6",
+    permit2: "0x000000000022D473030F116dDEE9F6B43aC78BA3",
+    hardhatNetwork: "arb-sepolia",
   },
   {
     name: "Opt Sepolia",
     rpcUrl: "https://sepolia.optimism.io",
     chainId: 11155420,
     nativeToken: "ETH",
+    gateway: "0xe432150cce91c13a887f7D836923d5597adD8E31",
+    gasService: "0xbE406F0189A0B4cf3A05C286473D23791Dd44Cc6",
+    permit2: "",
+    hardhatNetwork: "opt-sepolia",
   },
 ];
 

--- a/integration/verify-contract.ts
+++ b/integration/verify-contract.ts
@@ -1,0 +1,161 @@
+#!/usr/bin/env vite-node
+
+import { spawn } from "child_process";
+import * as path from "path";
+import { config } from "dotenv";
+import {
+  ChainConfig,
+  MAINNET_CHAINS,
+  TESTNET_CHAINS,
+  CHAIN_ALIASES,
+} from "./chain-config.js";
+
+config();
+
+const { REMOTE_ACCOUNT_FACTORY } = process.env;
+
+const resolveChain = (
+  alias: string,
+  isTestnet: boolean,
+): ChainConfig | undefined => {
+  const chains = isTestnet ? TESTNET_CHAINS : MAINNET_CHAINS;
+  const normalized = CHAIN_ALIASES[alias.toLowerCase()] ?? alias.toLowerCase();
+  return chains.find((c) => c.name.toLowerCase() === normalized);
+};
+
+type ContractType =
+  | "factory"
+  | "depositFactory"
+  | "remoteAccountFactory"
+  | "portfolioRouter";
+
+/**
+ * Build constructor args for `hardhat verify` based on contract type and chain config.
+ * Mirrors the env vars set by deploy.sh + ignition modules.
+ */
+const getConstructorArgs = (
+  contractType: ContractType,
+  chain: ChainConfig,
+): string[] => {
+  switch (contractType) {
+    case "factory":
+      // Factory(gateway, gasService)
+      return [chain.gateway, chain.gasService];
+
+    case "depositFactory":
+      // DepositFactory(gateway, gasService, permit2, factory, owner)
+      // owner is set per-deployment, must be passed via env or arg
+      throw new Error(
+        "depositFactory verification requires FACTORY and owner address — use manual args",
+      );
+
+    case "remoteAccountFactory":
+      // RemoteAccountFactory(principalCaip2, principalAccount, implementationAddress, vettingAuthority)
+      // These are all deployment-specific — use manual args
+      throw new Error(
+        "remoteAccountFactory verification requires deployment-specific args — use manual args",
+      );
+
+    case "portfolioRouter":
+      // RemoteAccountAxelarRouter(gateway, axelarSourceChain, factory, permit2)
+      if (!REMOTE_ACCOUNT_FACTORY) {
+        throw new Error(
+          "REMOTE_ACCOUNT_FACTORY env var required for portfolioRouter verification",
+        );
+      }
+      return [chain.gateway, "agoric", REMOTE_ACCOUNT_FACTORY, chain.permit2];
+
+    default:
+      throw new Error(`Unknown contract type: ${contractType}`);
+  }
+};
+
+const runHardhat = (args: string[], cwd: string): Promise<number> =>
+  new Promise((resolve) => {
+    const child = spawn("npx", ["hardhat", ...args], {
+      cwd,
+      stdio: "inherit",
+    });
+    child.on("close", (code) => resolve(code ?? 1));
+    child.on("error", (error) => {
+      console.error(`Failed to run hardhat: ${error.message}`);
+      resolve(1);
+    });
+  });
+
+const main = async () => {
+  const args = process.argv.slice(2);
+
+  if (args.length < 3) {
+    console.error(`
+Usage: vite-node verify-contract.ts <chain> <contract-type> <contract-address> [--testnet]
+
+Verifies a deployed contract on a block explorer using \`hardhat verify\`.
+Constructor args are resolved automatically from chain config and env vars.
+
+Arguments:
+  chain             - Target chain (e.g., base, eth, arb, opt, avax)
+  contract-type     - Contract type: factory, portfolioRouter
+  contract-address  - The deployed contract address
+  --testnet         - Use testnet chain config
+
+Environment Variables:
+  REMOTE_ACCOUNT_FACTORY  - Required for portfolioRouter
+
+Examples:
+  # Verify RemoteAccountAxelarRouter on Base
+  REMOTE_ACCOUNT_FACTORY=0x3B46...23A6 yarn verify-contract base portfolioRouter 0x2cB3...dA2c
+
+  # Verify Factory on Eth Sepolia
+  yarn verify-contract eth-sepolia factory 0x1234...abcd --testnet
+`);
+    process.exit(1);
+  }
+
+  const chainAlias = args[0];
+  const contractType = args[1] as ContractType;
+  const contractAddress = args[2];
+  const isTestnet = args.includes("--testnet");
+
+  const chainConfig = resolveChain(chainAlias, isTestnet);
+  if (!chainConfig) {
+    console.error(`Error: Unknown chain "${chainAlias}"`);
+    process.exit(1);
+  }
+
+  const constructorArgs = getConstructorArgs(contractType, chainConfig);
+
+  const cosmosDir = path.resolve(
+    __dirname,
+    "../packages/axelar-local-dev-cosmos",
+  );
+
+  console.log(`\n🔍 Verifying ${contractType} on ${chainConfig.name}...`);
+  console.log(`   Address: ${contractAddress}`);
+  console.log(`   Constructor args: ${constructorArgs.join(" ")}`);
+  console.log();
+
+  const hardhatArgs = [
+    "verify",
+    "--network",
+    chainConfig.hardhatNetwork,
+    contractAddress,
+    ...constructorArgs,
+  ];
+
+  const exitCode = await runHardhat(hardhatArgs, cosmosDir);
+
+  if (exitCode === 0) {
+    console.log(`\n✅ Verification succeeded on ${chainConfig.name}\n`);
+  } else {
+    console.error(
+      `\n❌ Verification failed on ${chainConfig.name} (exit code: ${exitCode})\n`,
+    );
+    process.exit(exitCode);
+  }
+};
+
+main().catch((error) => {
+  console.error("\n❌ Error:", error.message || error);
+  process.exit(1);
+});

--- a/integration/vet-router.ts
+++ b/integration/vet-router.ts
@@ -1,0 +1,131 @@
+#!/usr/bin/env vite-node
+
+import { ethers } from "ethers";
+import { config } from "dotenv";
+import {
+  MAINNET_CHAINS,
+  TESTNET_CHAINS,
+  CHAIN_ALIASES,
+} from "./chain-config.js";
+
+config();
+
+const { PRIVATE_KEY } = process.env;
+
+const FACTORY_ABI = [
+  "function vetInitialRouter(address router) external",
+  "function vetRouter(address router) external",
+  "function getRouterStatus(address router) external view returns (uint8)",
+  "function numberOfAuthorizedRouters() external view returns (uint256)",
+  "function vettingAuthority() external view returns (address)",
+];
+
+const ROUTER_STATUS = ["Unknown", "Vetted", "Authorized"] as const;
+
+const resolveChain = (alias: string, isTestnet: boolean) => {
+  const chains = isTestnet ? TESTNET_CHAINS : MAINNET_CHAINS;
+  const normalized = CHAIN_ALIASES[alias.toLowerCase()] ?? alias.toLowerCase();
+  return chains.find((c) => c.name.toLowerCase() === normalized);
+};
+
+const main = async () => {
+  const args = process.argv.slice(2);
+
+  if (args.length < 3) {
+    console.error(`
+Usage: vite-node vet-router.ts <chain> <factory-address> <router-address> [--testnet]
+
+Examples:
+  vite-node vet-router.ts base 0x3B46...23A6 0x2cB3...dA2c
+  vite-node vet-router.ts base-sepolia 0x3B46...23A6 0x2cB3...dA2c --testnet
+`);
+    process.exit(1);
+  }
+
+  if (!PRIVATE_KEY) {
+    console.error("Error: PRIVATE_KEY environment variable not set");
+    process.exit(1);
+  }
+
+  const chainAlias = args[0];
+  const factoryAddress = args[1];
+  const routerAddress = args[2];
+  const isTestnet = args.includes("--testnet");
+
+  const chainConfig = resolveChain(chainAlias, isTestnet);
+  if (!chainConfig) {
+    console.error(`Error: Unknown chain "${chainAlias}"`);
+    process.exit(1);
+  }
+
+  if (!ethers.isAddress(factoryAddress) || !ethers.isAddress(routerAddress)) {
+    console.error("Error: Invalid address provided");
+    process.exit(1);
+  }
+
+  const provider = new ethers.JsonRpcProvider(chainConfig.rpcUrl);
+  const wallet = new ethers.Wallet(PRIVATE_KEY, provider);
+  const factory = new ethers.Contract(factoryAddress, FACTORY_ABI, wallet);
+
+  console.log(`\n🔍 Checking router status on ${chainConfig.name}...\n`);
+
+  const [status, numberOfRouters, vettingAuthority] = await Promise.all([
+    factory.getRouterStatus(routerAddress),
+    factory.numberOfAuthorizedRouters(),
+    factory.vettingAuthority(),
+  ]);
+
+  const statusName = ROUTER_STATUS[Number(status)] ?? `Unknown(${status})`;
+
+  console.log(`  Router:             ${routerAddress}`);
+  console.log(`  Factory:            ${factoryAddress}`);
+  console.log(`  Status:             ${statusName}`);
+  console.log(`  Authorized Routers: ${numberOfRouters}`);
+  console.log(`  Vetting Authority:  ${vettingAuthority}`);
+  console.log(`  Wallet:             ${wallet.address}`);
+
+  if (vettingAuthority !== wallet.address) {
+    console.error("\n❌ Wallet is not the vetting authority. Cannot vet.");
+    process.exit(1);
+  }
+
+  if (status !== 0n) {
+    console.log(
+      `\n✅ Router already has status "${statusName}", no action needed.`,
+    );
+    process.exit(0);
+  }
+
+  if (numberOfRouters > 0n) {
+    console.log(
+      "\n⚠️  Other routers already authorized. Using vetRouter (two-factor flow).",
+    );
+    console.log("   Submitting vetRouter transaction...");
+    const tx = await factory.vetRouter(routerAddress);
+    const receipt = await tx.wait();
+    console.log(
+      `\n✅ vetRouter tx: ${receipt.hash} (status: ${receipt.status})`,
+    );
+    console.log(
+      "   Router is now Vetted. It must be authorized through an existing router.",
+    );
+  } else {
+    console.log("\n🚀 Submitting vetInitialRouter transaction...");
+    const tx = await factory.vetInitialRouter(routerAddress);
+    const receipt = await tx.wait();
+    console.log(
+      `\n✅ vetInitialRouter tx: ${receipt.hash} (status: ${receipt.status})`,
+    );
+  }
+
+  // Verify final state
+  const finalStatus = await factory.getRouterStatus(routerAddress);
+  console.log(
+    `   Final router status: ${ROUTER_STATUS[Number(finalStatus)] ?? finalStatus}\n`,
+  );
+};
+
+main().catch((error) => {
+  console.error("\n❌ Error:", error.message || error);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "decode": "cd integration && npx --silent vite-node decode-payload.ts",
     "check-balance": "cd integration && npx --silent vite-node check-wallet-balance.ts",
     "vet-router": "cd integration && npx --silent vite-node vet-router.ts",
+    "verify-contract": "cd integration && npx --silent vite-node verify-contract.ts",
     "sync-nonces": "cd packages/axelar-local-dev-cosmos && npx ts-node scripts/increment-nonce.ts",
     "check-gas": "cd packages/axelar-local-dev-cosmos && npx ts-node scripts/check-gas-price.ts"
   },

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "coverage:proxy": "lerna exec --scope=@axelar-network/axelar-local-dev-cosmos npm run coverage:proxy",
     "decode": "cd integration && npx --silent vite-node decode-payload.ts",
     "check-balance": "cd integration && npx --silent vite-node check-wallet-balance.ts",
+    "vet-router": "cd integration && npx --silent vite-node vet-router.ts",
     "sync-nonces": "cd packages/axelar-local-dev-cosmos && npx ts-node scripts/increment-nonce.ts",
     "check-gas": "cd packages/axelar-local-dev-cosmos && npx ts-node scripts/check-gas-price.ts"
   },


### PR DESCRIPTION
- Add `yarn vet-router` script to manually call `vetInitialRouter/vetRouter` on a factory contract, useful when the deploy pipeline fails after contract deployment but before vetting (e.g., [verification failure on Base](https://github.com/agoric-labs/agoric-to-axelar-local/actions/runs/23533819194/job/68503871589))
- Add `yarn verify-contract` script to retry contract verification without needing Hardhat Ignition deployment artifacts - resolves constructor args from chain config