### PR TITLE
chore: use create3 for router deployments

### DIFF
--- a/integration/deploy-all-chains.ts
+++ b/integration/deploy-all-chains.ts
@@ -289,11 +289,13 @@ const deployToAllChains = async (
   console.log(`Continue on Error: ${continueOnError}`);
   console.log("═══════════════════════════════════════════════════════════\n");
 
-  // CREATE2 deployments (via CreateX) produce nonce-independent addresses,
+  // CreateX deployments (CREATE2/CREATE3) produce nonce-independent addresses,
   // so nonce synchronization is unnecessary and skipped.
-  if (contract === "remoteAccountFactory") {
+  const isCreateX =
+    contract === "remoteAccountFactory" || contract === "portfolioRouter";
+  if (isCreateX) {
     console.log(
-      "\n⏭️  Skipping nonce synchronization (CREATE2 deployment is nonce-independent)\n",
+      "\n⏭️  Skipping nonce synchronization (CreateX deployment is nonce-independent)\n",
     );
   } else {
     // Sync nonces before deployment
@@ -337,12 +339,11 @@ const deployToAllChains = async (
     }
   } else {
     // Deploy to chains sequentially.
-    // For nonce-dependent (non-CREATE2) deployments, deploy ETH first because
+    // For nonce-dependent (non-CreateX) deployments, deploy ETH first because
     // gas spikes can cause failures — better to fail early so we can sync nonces.
-    // For CREATE2 deployments, ordering doesn't matter and failures on one chain
+    // For CreateX deployments, ordering doesn't matter and failures on one chain
     // don't affect others, so we continue past failures.
-    const isCreate2 = contract === "remoteAccountFactory";
-    const sortedChains = isCreate2
+    const sortedChains = isCreateX
       ? [...chains]
       : [...chains].sort((a, b) => {
           if (a === "eth") return -1;
@@ -355,9 +356,9 @@ const deployToAllChains = async (
       results.push(result);
 
       if (!result.success) {
-        if (isCreate2) {
+        if (isCreateX) {
           console.warn(
-            `\n⚠️  Deployment failed on ${chain}, continuing (CREATE2 is idempotent)...`,
+            `\n⚠️  Deployment failed on ${chain}, continuing (CreateX is idempotent)...`,
           );
         } else {
           console.error(

--- a/packages/axelar-local-dev-cosmos/scripts/createx-utils.ts
+++ b/packages/axelar-local-dev-cosmos/scripts/createx-utils.ts
@@ -1,0 +1,168 @@
+import '@nomicfoundation/hardhat-ethers';
+import { Contract } from 'ethers';
+import { ethers, network, run } from 'hardhat';
+
+const { concat, getAddress, keccak256, zeroPadValue } = ethers;
+
+// see https://github.com/pcaversaccio/createx?tab=readme-ov-file#createx-deployments
+export const CREATEX_ADDRESS = '0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed';
+// see https://github.com/pcaversaccio/createx?tab=readme-ov-file#security-considerations
+const CREATEX_RUNTIME_CODEHASH =
+    '0xbd8a7ea8cfca7b4e5f5041d7d4b17bc317c5ce42cfbc42066a00cf26b43eb53f';
+
+// see https://github.com/pcaversaccio/createx?tab=readme-ov-file#abi-application-binary-interface
+const CREATEX_ABI = [
+    'function deployCreate2(bytes32 salt, bytes memory initCode) external payable returns (address)',
+    'function computeCreate2Address(bytes32 salt, bytes32 initCodeHash) external view returns (address)',
+    'function deployCreate3(bytes32 salt, bytes memory initCode) external payable returns (address)',
+    'function computeCreate3Address(bytes32 salt) external view returns (address)',
+    'event ContractCreation(address indexed newContract, bytes32 indexed salt)',
+];
+
+/**
+ * Build a 32-byte CreateX permissioned salt.
+ * The `hashInput` is hashed to derive the 11-byte suffix, so the salt
+ * changes whenever the input changes (e.g. when bytecode is upgraded).
+ */
+export const buildPermissionedSalt = (deployer: string, hashInput: string): string => {
+    const normalizedDeployer = getAddress(deployer).slice(2).toLowerCase();
+    const inputHash = keccak256(hashInput).slice(2);
+    const suffix = inputHash.slice(0, 22); // 11 bytes = 22 hex chars
+
+    /**
+     * Permissioned salt layout:
+     * - 20 bytes: deployer address
+     * - 1 byte: permission marker (00)
+     * - 11 bytes: hashInput-derived suffix
+     */
+    const salt = `0x${normalizedDeployer}00${suffix}`;
+    if (salt.length !== 66) {
+        throw new Error(`Invalid salt length: ${salt}`);
+    }
+    return salt;
+};
+
+/**
+ * Replicate CreateX's `_guard` for the permissioned-salt case.
+ */
+const computeGuardedSalt = (deployer: string, rawSalt: string): string => {
+    const deployerWord = zeroPadValue(deployer, 32);
+    return keccak256(concat([deployerWord, rawSalt]));
+};
+
+export const validateCreateX = async (): Promise<void> => {
+    const runtimeCode = await ethers.provider.getCode(CREATEX_ADDRESS);
+    if (runtimeCode === '0x') {
+        throw new Error(`CreateX not found at ${CREATEX_ADDRESS} on ${network.name}`);
+    }
+    const codeHash = keccak256(runtimeCode);
+    if (codeHash !== CREATEX_RUNTIME_CODEHASH) {
+        throw new Error(
+            `CreateX bytecode mismatch on ${network.name}\n` +
+                `  expected: ${CREATEX_RUNTIME_CODEHASH}\n` +
+                `  got:      ${codeHash}`,
+        );
+    }
+};
+
+export const getCreateX = (signer: any): Contract => {
+    return new Contract(CREATEX_ADDRESS, CREATEX_ABI, signer);
+};
+
+export interface DeployResult {
+    address: string;
+    alreadyDeployed: boolean;
+}
+
+type DeployViaCreateXArgs = {
+    createX: Contract;
+    deployer: string;
+    rawSalt: string;
+    initCode: string;
+    label: string;
+} & ({ mode: 'create2' } | { mode: 'create3' });
+
+const computeExpectedAddress = async (
+    createX: Contract,
+    deployer: string,
+    rawSalt: string,
+    initCode: string,
+    mode: 'create2' | 'create3',
+): Promise<string> => {
+    const guardedSalt = computeGuardedSalt(deployer, rawSalt);
+    if (mode === 'create2') {
+        const initCodeHash = keccak256(initCode);
+        return await createX.computeCreate2Address(guardedSalt, initCodeHash);
+    }
+    return await createX.computeCreate3Address(guardedSalt);
+};
+
+export const deployViaCreateX = async (args: DeployViaCreateXArgs): Promise<DeployResult> => {
+    const { createX, deployer, rawSalt, initCode, label, mode } = args;
+    const expectedAddress = await computeExpectedAddress(
+        createX,
+        deployer,
+        rawSalt,
+        initCode,
+        mode,
+    );
+
+    const existingCode = await ethers.provider.getCode(expectedAddress);
+    if (existingCode !== '0x') {
+        console.log(`  ${label}: ${expectedAddress} (exists, skipped)`);
+        return { address: expectedAddress, alreadyDeployed: true };
+    }
+
+    const tx =
+        mode === 'create2'
+            ? await createX.deployCreate2(rawSalt, initCode)
+            : await createX.deployCreate3(rawSalt, initCode);
+    const receipt = await tx.wait(5);
+
+    // Verify address from ContractCreation event
+    const eventTopic = createX.interface.getEvent('ContractCreation')!.topicHash;
+    const creationLog = receipt.logs.find(
+        (log: any) =>
+            log.topics[0] === eventTopic &&
+            log.address.toLowerCase() === CREATEX_ADDRESS.toLowerCase(),
+    );
+    if (creationLog) {
+        const parsed = createX.interface.parseLog({
+            topics: creationLog.topics,
+            data: creationLog.data,
+        });
+        const actualAddress = parsed?.args?.newContract;
+        if (actualAddress && actualAddress.toLowerCase() !== expectedAddress.toLowerCase()) {
+            throw new Error(
+                `${label}: address mismatch — expected ${expectedAddress}, got ${actualAddress}`,
+            );
+        }
+    } else {
+        console.warn(`  ⚠ ${label}: ContractCreation event not found in receipt logs`);
+    }
+
+    console.log(`  ${label}: ${expectedAddress} (deployed, tx ${receipt.hash})`);
+    return { address: expectedAddress, alreadyDeployed: false };
+};
+
+export const verifyOnExplorer = async ({
+    address,
+    constructorArgs,
+    contract,
+}: {
+    address: string;
+    constructorArgs: unknown[];
+    contract: string;
+}): Promise<void> => {
+    try {
+        await run('verify:verify', { address, constructorArgs, contract });
+        console.log(`  Verified ${contract}`);
+    } catch (error: any) {
+        const msg: string = error.message ?? '';
+        if (msg.includes('Already Verified') || msg.includes('already verified')) {
+            console.log(`  Already verified: ${contract}`);
+        } else {
+            console.warn(`  Verification failed (non-fatal): ${msg}`);
+        }
+    }
+};

--- a/packages/axelar-local-dev-cosmos/scripts/deploy.sh
+++ b/packages/axelar-local-dev-cosmos/scripts/deploy.sh
@@ -162,24 +162,11 @@ case "$contract" in
         # networks currently share the same value.
         AXELAR_SOURCE_CHAIN="agoric"
 
-        echo ""
-        echo "========================================="
-        echo "Deploying RemoteAccountAxelarRouter..."
-        echo "========================================="
-        echo "Using RemoteAccountFactory: $REMOTE_ACCOUNT_FACTORY"
-        echo "Using Axelar Source Chain: $AXELAR_SOURCE_CHAIN"
-
         GATEWAY_CONTRACT="$GATEWAY" \
             AXELAR_SOURCE_CHAIN="$AXELAR_SOURCE_CHAIN" \
             FACTORY_CONTRACT="$REMOTE_ACCOUNT_FACTORY" \
             PERMIT2_CONTRACT="$PERMIT2" \
-            npx hardhat ignition deploy "./ignition/modules/deployPortfolioRouter.ts" --network "$network" --verify
-        # Vet router after deployment
-        GATEWAY_CONTRACT="$GATEWAY" \
-            AXELAR_SOURCE_CHAIN="$AXELAR_SOURCE_CHAIN" \
-            FACTORY_CONTRACT="$REMOTE_ACCOUNT_FACTORY" \
-            PERMIT2_CONTRACT="$PERMIT2" \
-            npx hardhat run "./scripts/deployAndVetPortfolioRouter.mts" --network "$network"
+            npx hardhat run "./scripts/deployPortfolioRouter.ts" --network "$network"
         ;;
     *)
         echo "Error: Invalid contract type '$contract'"

--- a/packages/axelar-local-dev-cosmos/scripts/deployPortfolioRouter.ts
+++ b/packages/axelar-local-dev-cosmos/scripts/deployPortfolioRouter.ts
@@ -1,150 +1,15 @@
 import '@nomicfoundation/hardhat-ethers';
-import { Contract } from 'ethers';
-import { ethers, network, run } from 'hardhat';
+import { ethers, network } from 'hardhat';
 
-const { concat, getAddress, isAddress, keccak256, zeroPadValue } = ethers;
+const { isAddress } = ethers;
 
-// see https://github.com/pcaversaccio/createx?tab=readme-ov-file#createx-deployments
-const CREATEX_ADDRESS = '0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed';
-// see https://github.com/pcaversaccio/createx?tab=readme-ov-file#security-considerations
-const CREATEX_RUNTIME_CODEHASH =
-    '0xbd8a7ea8cfca7b4e5f5041d7d4b17bc317c5ce42cfbc42066a00cf26b43eb53f';
-
-const CREATEX_ABI = [
-    'function deployCreate3(bytes32 salt, bytes memory initCode) external payable returns (address)',
-    'function computeCreate3Address(bytes32 salt) external view returns (address)',
-    'event ContractCreation(address indexed newContract, bytes32 indexed salt)',
-];
-
-/**
- * Build a 32-byte CreateX permissioned salt derived from the initCode.
- * This ensures the salt changes whenever the bytecode or constructor args change.
- */
-const buildPermissionedSalt = (deployer: string, initCode: string): string => {
-    const normalizedDeployer = getAddress(deployer).slice(2).toLowerCase();
-    const initCodeHash = keccak256(initCode).slice(2);
-    const suffix = initCodeHash.slice(0, 22); // 11 bytes = 22 hex chars
-
-    /**
-     * Permissioned salt layout:
-     * - 20 bytes: deployer address
-     * - 1 byte: permission marker (00)
-     * - 11 bytes: initCode-derived suffix
-     */
-    const salt = `0x${normalizedDeployer}00${suffix}`;
-    if (salt.length !== 66) {
-        throw new Error(`Invalid salt length: ${salt}`);
-    }
-    return salt;
-};
-
-/**
- * Replicate CreateX's `_guard` for the permissioned-salt case.
- * CREATE3 address depends only on deployer + salt, not initCode.
- */
-const computeGuardedSalt = (deployer: string, rawSalt: string): string => {
-    const deployerWord = zeroPadValue(deployer, 32);
-    return keccak256(concat([deployerWord, rawSalt]));
-};
-
-const computeExpectedCreate3Address = async (
-    createX: Contract,
-    deployer: string,
-    rawSalt: string,
-): Promise<string> => {
-    const guardedSalt = computeGuardedSalt(deployer, rawSalt);
-    return await createX.computeCreate3Address(guardedSalt);
-};
-
-const validateCreateX = async (): Promise<void> => {
-    const runtimeCode = await ethers.provider.getCode(CREATEX_ADDRESS);
-    if (runtimeCode === '0x') {
-        throw new Error(`CreateX not found at ${CREATEX_ADDRESS} on ${network.name}`);
-    }
-    const codeHash = keccak256(runtimeCode);
-    if (codeHash !== CREATEX_RUNTIME_CODEHASH) {
-        throw new Error(
-            `CreateX bytecode mismatch on ${network.name}\n` +
-                `  expected: ${CREATEX_RUNTIME_CODEHASH}\n` +
-                `  got:      ${codeHash}`,
-        );
-    }
-};
-
-interface DeployResult {
-    address: string;
-    alreadyDeployed: boolean;
-}
-
-const deployViaCreate3 = async ({
-    createX,
-    deployer,
-    rawSalt,
-    initCode,
-    label,
-}: {
-    createX: Contract;
-    deployer: string;
-    rawSalt: string;
-    initCode: string;
-    label: string;
-}): Promise<DeployResult> => {
-    const expectedAddress = await computeExpectedCreate3Address(createX, deployer, rawSalt);
-
-    const existingCode = await ethers.provider.getCode(expectedAddress);
-    if (existingCode !== '0x') {
-        console.log(`  ${label}: ${expectedAddress} (exists, skipped)`);
-        return { address: expectedAddress, alreadyDeployed: true };
-    }
-
-    const tx = await createX.deployCreate3(rawSalt, initCode);
-    const receipt = await tx.wait(5);
-
-    // Verify address from ContractCreation event
-    const eventTopic = createX.interface.getEvent('ContractCreation')!.topicHash;
-    const creationLog = receipt.logs.find(
-        (log: any) =>
-            log.topics[0] === eventTopic &&
-            log.address.toLowerCase() === CREATEX_ADDRESS.toLowerCase(),
-    );
-    if (creationLog) {
-        const parsed = createX.interface.parseLog({
-            topics: creationLog.topics,
-            data: creationLog.data,
-        });
-        const actualAddress = parsed?.args?.newContract;
-        if (actualAddress && actualAddress.toLowerCase() !== expectedAddress.toLowerCase()) {
-            throw new Error(
-                `${label}: address mismatch — expected ${expectedAddress}, got ${actualAddress}`,
-            );
-        }
-    }
-
-    console.log(`  ${label}: ${expectedAddress} (deployed, tx ${receipt.hash})`);
-    return { address: expectedAddress, alreadyDeployed: false };
-};
-
-const verifyOnExplorer = async ({
-    address,
-    constructorArgs,
-    contract,
-}: {
-    address: string;
-    constructorArgs: unknown[];
-    contract: string;
-}): Promise<void> => {
-    try {
-        await run('verify:verify', { address, constructorArgs, contract });
-        console.log(`  Verified ${contract}`);
-    } catch (error: any) {
-        const msg: string = error.message ?? '';
-        if (msg.includes('Already Verified') || msg.includes('already verified')) {
-            console.log(`  Already verified: ${contract}`);
-        } else {
-            console.warn(`  Verification failed (non-fatal): ${msg}`);
-        }
-    }
-};
+import {
+    buildPermissionedSalt,
+    deployViaCreateX,
+    getCreateX,
+    validateCreateX,
+    verifyOnExplorer,
+} from './createx-utils.ts';
 
 const vetRouter = async (routerAddress: string, factoryAddress: string): Promise<void> => {
     const [deployer] = await ethers.getSigners();
@@ -209,7 +74,7 @@ const main = async () => {
     console.log(`  Permit2:           ${PERMIT2_CONTRACT}\n`);
 
     await validateCreateX();
-    const createX = new Contract(CREATEX_ADDRESS, CREATEX_ABI, deployer);
+    const createX = getCreateX(deployer);
 
     // Deploy RemoteAccountAxelarRouter via CREATE3
     console.log('RemoteAccountAxelarRouter:');
@@ -227,12 +92,13 @@ const main = async () => {
     // Constructor args include the gateway address which differs per chain,
     // but CREATE3 address depends only on deployer + salt, not initCode.
     const rawSalt = buildPermissionedSalt(deployerAddress, RouterCF.bytecode);
-    const routerResult = await deployViaCreate3({
+    const routerResult = await deployViaCreateX({
         createX,
         deployer: deployerAddress,
         rawSalt,
         initCode: routerDeployTx.data,
         label: 'RemoteAccountAxelarRouter',
+        mode: 'create3',
     });
 
     // Verification

--- a/packages/axelar-local-dev-cosmos/scripts/deployPortfolioRouter.ts
+++ b/packages/axelar-local-dev-cosmos/scripts/deployPortfolioRouter.ts
@@ -1,0 +1,257 @@
+import '@nomicfoundation/hardhat-ethers';
+import { Contract } from 'ethers';
+import { ethers, network, run } from 'hardhat';
+
+const { concat, getAddress, isAddress, keccak256, zeroPadValue } = ethers;
+
+// see https://github.com/pcaversaccio/createx?tab=readme-ov-file#createx-deployments
+const CREATEX_ADDRESS = '0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed';
+// see https://github.com/pcaversaccio/createx?tab=readme-ov-file#security-considerations
+const CREATEX_RUNTIME_CODEHASH =
+    '0xbd8a7ea8cfca7b4e5f5041d7d4b17bc317c5ce42cfbc42066a00cf26b43eb53f';
+
+const CREATEX_ABI = [
+    'function deployCreate3(bytes32 salt, bytes memory initCode) external payable returns (address)',
+    'function computeCreate3Address(bytes32 salt) external view returns (address)',
+    'event ContractCreation(address indexed newContract, bytes32 indexed salt)',
+];
+
+/**
+ * Build a 32-byte CreateX permissioned salt derived from the initCode.
+ * This ensures the salt changes whenever the bytecode or constructor args change.
+ */
+const buildPermissionedSalt = (deployer: string, initCode: string): string => {
+    const normalizedDeployer = getAddress(deployer).slice(2).toLowerCase();
+    const initCodeHash = keccak256(initCode).slice(2);
+    const suffix = initCodeHash.slice(0, 22); // 11 bytes = 22 hex chars
+
+    /**
+     * Permissioned salt layout:
+     * - 20 bytes: deployer address
+     * - 1 byte: permission marker (00)
+     * - 11 bytes: initCode-derived suffix
+     */
+    const salt = `0x${normalizedDeployer}00${suffix}`;
+    if (salt.length !== 66) {
+        throw new Error(`Invalid salt length: ${salt}`);
+    }
+    return salt;
+};
+
+/**
+ * Replicate CreateX's `_guard` for the permissioned-salt case.
+ * CREATE3 address depends only on deployer + salt, not initCode.
+ */
+const computeGuardedSalt = (deployer: string, rawSalt: string): string => {
+    const deployerWord = zeroPadValue(deployer, 32);
+    return keccak256(concat([deployerWord, rawSalt]));
+};
+
+const computeExpectedCreate3Address = async (
+    createX: Contract,
+    deployer: string,
+    rawSalt: string,
+): Promise<string> => {
+    const guardedSalt = computeGuardedSalt(deployer, rawSalt);
+    return await createX.computeCreate3Address(guardedSalt);
+};
+
+const validateCreateX = async (): Promise<void> => {
+    const runtimeCode = await ethers.provider.getCode(CREATEX_ADDRESS);
+    if (runtimeCode === '0x') {
+        throw new Error(`CreateX not found at ${CREATEX_ADDRESS} on ${network.name}`);
+    }
+    const codeHash = keccak256(runtimeCode);
+    if (codeHash !== CREATEX_RUNTIME_CODEHASH) {
+        throw new Error(
+            `CreateX bytecode mismatch on ${network.name}\n` +
+                `  expected: ${CREATEX_RUNTIME_CODEHASH}\n` +
+                `  got:      ${codeHash}`,
+        );
+    }
+};
+
+interface DeployResult {
+    address: string;
+    alreadyDeployed: boolean;
+}
+
+const deployViaCreate3 = async ({
+    createX,
+    deployer,
+    rawSalt,
+    initCode,
+    label,
+}: {
+    createX: Contract;
+    deployer: string;
+    rawSalt: string;
+    initCode: string;
+    label: string;
+}): Promise<DeployResult> => {
+    const expectedAddress = await computeExpectedCreate3Address(createX, deployer, rawSalt);
+
+    const existingCode = await ethers.provider.getCode(expectedAddress);
+    if (existingCode !== '0x') {
+        console.log(`  ${label}: ${expectedAddress} (exists, skipped)`);
+        return { address: expectedAddress, alreadyDeployed: true };
+    }
+
+    const tx = await createX.deployCreate3(rawSalt, initCode);
+    const receipt = await tx.wait(5);
+
+    // Verify address from ContractCreation event
+    const eventTopic = createX.interface.getEvent('ContractCreation')!.topicHash;
+    const creationLog = receipt.logs.find(
+        (log: any) =>
+            log.topics[0] === eventTopic &&
+            log.address.toLowerCase() === CREATEX_ADDRESS.toLowerCase(),
+    );
+    if (creationLog) {
+        const parsed = createX.interface.parseLog({
+            topics: creationLog.topics,
+            data: creationLog.data,
+        });
+        const actualAddress = parsed?.args?.newContract;
+        if (actualAddress && actualAddress.toLowerCase() !== expectedAddress.toLowerCase()) {
+            throw new Error(
+                `${label}: address mismatch — expected ${expectedAddress}, got ${actualAddress}`,
+            );
+        }
+    }
+
+    console.log(`  ${label}: ${expectedAddress} (deployed, tx ${receipt.hash})`);
+    return { address: expectedAddress, alreadyDeployed: false };
+};
+
+const verifyOnExplorer = async ({
+    address,
+    constructorArgs,
+    contract,
+}: {
+    address: string;
+    constructorArgs: unknown[];
+    contract: string;
+}): Promise<void> => {
+    try {
+        await run('verify:verify', { address, constructorArgs, contract });
+        console.log(`  Verified ${contract}`);
+    } catch (error: any) {
+        const msg: string = error.message ?? '';
+        if (msg.includes('Already Verified') || msg.includes('already verified')) {
+            console.log(`  Already verified: ${contract}`);
+        } else {
+            console.warn(`  Verification failed (non-fatal): ${msg}`);
+        }
+    }
+};
+
+const vetRouter = async (routerAddress: string, factoryAddress: string): Promise<void> => {
+    const [deployer] = await ethers.getSigners();
+    const factory = await ethers.getContractAt('RemoteAccountFactory', factoryAddress);
+
+    const [status, numberOfRouters, vettingAuthority] = await Promise.all([
+        factory.getRouterStatus(routerAddress),
+        factory.numberOfAuthorizedRouters(),
+        factory.vettingAuthority(),
+    ]);
+
+    console.log(`\nPost-deployment vetting:`);
+    console.log(`  Router:            ${routerAddress}`);
+    console.log(`  Status in factory: ${status}`);
+    console.log(`  Authorized routers: ${numberOfRouters}`);
+    console.log(`  Vetting authority: ${vettingAuthority}`);
+
+    if (status !== 0n) {
+        console.log('  Router status already set, skipping vetting.');
+    } else if (vettingAuthority !== deployer.address) {
+        console.warn('  Deployer is not the vetting authority. Skipping vetting.');
+    } else if (numberOfRouters > 0n) {
+        console.log('  Vetting router (not initial — must be enabled through an existing router).');
+        const vetTx = await factory.vetRouter(routerAddress);
+        const vetReceipt = await vetTx.wait();
+        console.log(`  vetRouter tx: ${vetReceipt.hash} (status: ${vetReceipt.status})`);
+    } else {
+        console.log('  Vetting and enabling initial router.');
+        const vetTx = await factory.vetInitialRouter(routerAddress);
+        const vetReceipt = await vetTx.wait();
+        console.log(`  vetInitialRouter tx: ${vetReceipt.hash} (status: ${vetReceipt.status})`);
+    }
+};
+
+const main = async () => {
+    const { GATEWAY_CONTRACT, AXELAR_SOURCE_CHAIN, FACTORY_CONTRACT, PERMIT2_CONTRACT } =
+        process.env;
+    if (!GATEWAY_CONTRACT || !AXELAR_SOURCE_CHAIN || !FACTORY_CONTRACT || !PERMIT2_CONTRACT) {
+        throw new Error(
+            'Missing env: GATEWAY_CONTRACT, AXELAR_SOURCE_CHAIN, FACTORY_CONTRACT, or PERMIT2_CONTRACT',
+        );
+    }
+    if (!isAddress(GATEWAY_CONTRACT)) {
+        throw new Error(`Invalid GATEWAY_CONTRACT: ${GATEWAY_CONTRACT}`);
+    }
+    if (!isAddress(FACTORY_CONTRACT)) {
+        throw new Error(`Invalid FACTORY_CONTRACT: ${FACTORY_CONTRACT}`);
+    }
+    if (!isAddress(PERMIT2_CONTRACT)) {
+        throw new Error(`Invalid PERMIT2_CONTRACT: ${PERMIT2_CONTRACT}`);
+    }
+
+    const [deployer] = await ethers.getSigners();
+    const deployerAddress = await deployer.getAddress();
+    const { chainId } = await ethers.provider.getNetwork();
+
+    console.log(`\nCreateX CREATE3 Deploy — ${network.name} (${chainId})`);
+    console.log(`  Deployer:          ${deployerAddress}`);
+    console.log(`  Gateway:           ${GATEWAY_CONTRACT}`);
+    console.log(`  Source Chain:      ${AXELAR_SOURCE_CHAIN}`);
+    console.log(`  Factory:           ${FACTORY_CONTRACT}`);
+    console.log(`  Permit2:           ${PERMIT2_CONTRACT}\n`);
+
+    await validateCreateX();
+    const createX = new Contract(CREATEX_ADDRESS, CREATEX_ABI, deployer);
+
+    // Deploy RemoteAccountAxelarRouter via CREATE3
+    console.log('RemoteAccountAxelarRouter:');
+    const RouterCF = await ethers.getContractFactory('RemoteAccountAxelarRouter');
+    const routerDeployTx = await RouterCF.getDeployTransaction(
+        GATEWAY_CONTRACT,
+        AXELAR_SOURCE_CHAIN,
+        FACTORY_CONTRACT,
+        PERMIT2_CONTRACT,
+    );
+    if (!routerDeployTx.data) {
+        throw new Error('Failed to encode RemoteAccountAxelarRouter initCode');
+    }
+    // Use bytecode only (not full initCode) so the salt is chain-independent.
+    // Constructor args include the gateway address which differs per chain,
+    // but CREATE3 address depends only on deployer + salt, not initCode.
+    const rawSalt = buildPermissionedSalt(deployerAddress, RouterCF.bytecode);
+    const routerResult = await deployViaCreate3({
+        createX,
+        deployer: deployerAddress,
+        rawSalt,
+        initCode: routerDeployTx.data,
+        label: 'RemoteAccountAxelarRouter',
+    });
+
+    // Verification
+    await verifyOnExplorer({
+        address: routerResult.address,
+        constructorArgs: [
+            GATEWAY_CONTRACT,
+            AXELAR_SOURCE_CHAIN,
+            FACTORY_CONTRACT,
+            PERMIT2_CONTRACT,
+        ],
+        contract: 'src/contracts/RemoteAccountAxelarRouter.sol:RemoteAccountAxelarRouter',
+    });
+
+    // Vet router in factory
+    await vetRouter(routerResult.address, FACTORY_CONTRACT);
+};
+
+main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+});

--- a/packages/axelar-local-dev-cosmos/scripts/deployRemoteAccountFactory.ts
+++ b/packages/axelar-local-dev-cosmos/scripts/deployRemoteAccountFactory.ts
@@ -1,154 +1,15 @@
 import '@nomicfoundation/hardhat-ethers';
-import { Contract } from 'ethers';
-import { ethers, network, run } from 'hardhat';
+import { ethers, network } from 'hardhat';
 
-const { concat, getAddress, isAddress, keccak256, zeroPadValue } = ethers;
+const { isAddress } = ethers;
 
-// see https://github.com/pcaversaccio/createx?tab=readme-ov-file#createx-deployments
-const CREATEX_ADDRESS = '0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed';
-// see https://github.com/pcaversaccio/createx?tab=readme-ov-file#security-considerations
-const CREATEX_RUNTIME_CODEHASH =
-    '0xbd8a7ea8cfca7b4e5f5041d7d4b17bc317c5ce42cfbc42066a00cf26b43eb53f';
-
-// see https://github.com/pcaversaccio/createx?tab=readme-ov-file#abi-application-binary-interface
-const CREATEX_ABI = [
-    'function deployCreate2(bytes32 salt, bytes memory initCode) external payable returns (address)',
-    'function computeCreate2Address(bytes32 salt, bytes32 initCodeHash) external view returns (address)',
-    'event ContractCreation(address indexed newContract, bytes32 indexed salt)',
-];
-
-/**
- * Build a 32-byte CreateX salt derived from the initCode.
- * This ensures the salt changes whenever the bytecode or constructor args change.
- */
-const buildPermissionedSalt = (deployer: string, initCode: string): string => {
-    const normalizedDeployer = getAddress(deployer).slice(2).toLowerCase();
-    const initCodeHash = keccak256(initCode).slice(2);
-    const suffix = initCodeHash.slice(0, 22); // 11 bytes = 22 hex chars
-
-    /**
-     * Permissioned salt layout:
-     * - 20 bytes: deployer address
-     * - 1 byte: permission marker (00)
-     * - 11 bytes: initCode-derived suffix
-     */
-    const salt = `0x${normalizedDeployer}00${suffix}`;
-    if (salt.length !== 66) {
-        throw new Error(`Invalid salt length: ${salt}`);
-    }
-    return salt;
-};
-
-/**
- * Replicate CreateX's `_guard` for the permissioned-salt case
- */
-const computeGuardedSalt = (deployer: string, rawSalt: string): string => {
-    const deployerWord = zeroPadValue(deployer, 32);
-    return keccak256(concat([deployerWord, rawSalt]));
-};
-
-const computeExpectedAddress = async (
-    createX: Contract,
-    deployer: string,
-    rawSalt: string,
-    initCode: string,
-): Promise<string> => {
-    const guardedSalt = computeGuardedSalt(deployer, rawSalt);
-    const initCodeHash = keccak256(initCode);
-    return await createX.computeCreate2Address(guardedSalt, initCodeHash);
-};
-
-const validateCreateX = async (): Promise<void> => {
-    const runtimeCode = await ethers.provider.getCode(CREATEX_ADDRESS);
-    if (runtimeCode === '0x') {
-        throw new Error(`CreateX not found at ${CREATEX_ADDRESS} on ${network.name}`);
-    }
-    const codeHash = keccak256(runtimeCode);
-    if (codeHash !== CREATEX_RUNTIME_CODEHASH) {
-        throw new Error(
-            `CreateX bytecode mismatch on ${network.name}\n` +
-                `  expected: ${CREATEX_RUNTIME_CODEHASH}\n` +
-                `  got:      ${codeHash}`,
-        );
-    }
-};
-
-interface DeployResult {
-    address: string;
-    alreadyDeployed: boolean;
-}
-
-const deployViaCreateX = async ({
-    createX,
-    deployer,
-    rawSalt,
-    initCode,
-    label,
-}: {
-    createX: Contract;
-    deployer: string;
-    rawSalt: string;
-    initCode: string;
-    label: string;
-}): Promise<DeployResult> => {
-    const expectedAddress = await computeExpectedAddress(createX, deployer, rawSalt, initCode);
-
-    const existingCode = await ethers.provider.getCode(expectedAddress);
-    if (existingCode !== '0x') {
-        console.log(`  ${label}: ${expectedAddress} (exists, skipped)`);
-        return { address: expectedAddress, alreadyDeployed: true };
-    }
-
-    const tx = await createX.deployCreate2(rawSalt, initCode);
-    const receipt = await tx.wait(5);
-
-    // Verify address from ContractCreation event
-    const eventTopic = createX.interface.getEvent('ContractCreation')!.topicHash;
-    const creationLog = receipt.logs.find(
-        (log: any) =>
-            log.topics[0] === eventTopic &&
-            log.address.toLowerCase() === CREATEX_ADDRESS.toLowerCase(),
-    );
-    if (creationLog) {
-        const parsed = createX.interface.parseLog({
-            topics: creationLog.topics,
-            data: creationLog.data,
-        });
-        const actualAddress = parsed?.args?.newContract;
-        if (actualAddress && actualAddress.toLowerCase() !== expectedAddress.toLowerCase()) {
-            throw new Error(
-                `${label}: address mismatch — expected ${expectedAddress}, got ${actualAddress}`,
-            );
-        }
-    } else {
-        console.warn(`  ⚠ ${label}: ContractCreation event not found in receipt logs`);
-    }
-
-    console.log(`  ${label}: ${expectedAddress} (deployed, tx ${receipt.hash})`);
-    return { address: expectedAddress, alreadyDeployed: false };
-};
-
-const verifyOnExplorer = async ({
-    address,
-    constructorArgs,
-    contract,
-}: {
-    address: string;
-    constructorArgs: unknown[];
-    contract: string;
-}): Promise<void> => {
-    try {
-        await run('verify:verify', { address, constructorArgs, contract });
-        console.log(`  Verified ${contract}`);
-    } catch (error: any) {
-        const msg: string = error.message ?? '';
-        if (msg.includes('Already Verified') || msg.includes('already verified')) {
-            console.log(`  Already verified: ${contract}`);
-        } else {
-            console.warn(`  Verification failed (non-fatal): ${msg}`);
-        }
-    }
-};
+import {
+    buildPermissionedSalt,
+    deployViaCreateX,
+    getCreateX,
+    validateCreateX,
+    verifyOnExplorer,
+} from './createx-utils.ts';
 
 const main = async () => {
     const { PRINCIPAL_CAIP2, PRINCIPAL_ACCOUNT, VETTING_AUTHORITY } = process.env;
@@ -170,7 +31,7 @@ const main = async () => {
     console.log(`  Vetting Authority: ${VETTING_AUTHORITY}\n`);
 
     await validateCreateX();
-    const createX = new Contract(CREATEX_ADDRESS, CREATEX_ABI, deployer);
+    const createX = getCreateX(deployer);
 
     // Step 1: RemoteAccount (implementation)
     console.log('RemoteAccount (implementation):');
@@ -182,6 +43,7 @@ const main = async () => {
         rawSalt: implRawSalt,
         initCode: RemoteAccountCF.bytecode,
         label: 'RemoteAccount',
+        mode: 'create2',
     });
 
     // Step 2: RemoteAccountFactory
@@ -203,6 +65,7 @@ const main = async () => {
         rawSalt: factoryRawSalt,
         initCode: factoryDeployTx.data,
         label: 'RemoteAccountFactory',
+        mode: 'create2',
     });
 
     // Verification — always attempt, even for already-deployed contracts,


### PR DESCRIPTION
closes: https://linear.app/agoric/issue/PAK-207/use-create3-for-router-deployments

- Deploy `RemoteAccountAxelarRouter` via CreateX `CREATE3`, producing the same deterministic address across all chains regardless of differing constructor params. 
- Integrate router vetting into the deployment script