### PR TITLE
chore: emit Initialized event with principal in RemoteAccount

### DIFF
--- a/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountCreation.spec.ts
+++ b/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountCreation.spec.ts
@@ -100,6 +100,13 @@ describe('RemoteAccountAxelarRouter - RemoteAccountCreation', () => {
         const expectedAccountAddress = await route(portfolioLCA).getRemoteAccountAddress();
         const account = await ethers.getContractAt('RemoteAccount', expectedAccountAddress);
         expect(await account.factory()).to.equal(factory.target);
+
+        // Verify the Initialized event was emitted with the correct principal
+        const logs = receipt.parseLogs(account.interface);
+        const initializedEvent = logs.find((l) => l.name === 'Initialized');
+        expect(initializedEvent, 'Initialized event not found').to.not.equal(undefined);
+        expect(initializedEvent!.args.factory).to.equal(factory.target);
+        expect(initializedEvent!.args.principalAccount).to.equal(portfolioLCA);
     });
 
     it('should be idempotent - providing same account twice succeeds', async () => {
@@ -199,10 +206,9 @@ describe('RemoteAccountAxelarRouter - RemoteAccountCreation', () => {
         const account = await ethers.getContractAt('RemoteAccount', implementationAddress);
 
         // Try to call initialize on the implementation contract
-        await expect(account.initialize(addr1.address)).to.be.revertedWithCustomError(
-            account,
-            'InvalidInitialization',
-        );
+        await expect(
+            account.initialize(addr1.address, 'agoric1test'),
+        ).to.be.revertedWithCustomError(account, 'InvalidInitialization');
     });
 
     it('should disallow re-initializing a clone', async () => {
@@ -214,7 +220,7 @@ describe('RemoteAccountAxelarRouter - RemoteAccountCreation', () => {
         const account = await ethers.getContractAt('RemoteAccount', accountAddress);
 
         // Try to call initialize again on the clone
-        await expect(account.initialize(addr1.address)).to.be.revertedWithCustomError(
+        await expect(account.initialize(addr1.address, lca)).to.be.revertedWithCustomError(
             account,
             'InvalidInitialization',
         );

--- a/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccount.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccount.sol
@@ -33,11 +33,13 @@ contract RemoteAccount is Initializable, IRemoteAccount {
      *      deploying this contract using proxies must call this function on
      *      each clone after deploying it.
      * @param factory_ The factory that deployed this clone
+     * @param principalAccount The principal account string this clone represents
      */
-    function initialize(address factory_) external initializer {
+    function initialize(address factory_, string calldata principalAccount) external initializer {
         assert(factory == address(0));
         require(factory_ != address(0));
         factory = factory_;
+        emit Initialized(factory_, principalAccount);
     }
 
     /**

--- a/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountFactory.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountFactory.sol
@@ -115,7 +115,7 @@ contract RemoteAccountFactory is IRemoteAccountFactory {
         } catch {
             revert InvalidImplementation(implementation_);
         }
-        try RemoteAccount(payable(implementation_)).initialize(address(0)) {
+        try RemoteAccount(payable(implementation_)).initialize(address(0), '') {
             revert InvalidImplementation(implementation_);
         } catch {
             // Expected to revert because the implementation should have initializers disabled
@@ -254,7 +254,7 @@ contract RemoteAccountFactory is IRemoteAccountFactory {
 
         // Initialize the clone with this factory's address.
         // The clone immutably delegates authorization to this factory.
-        RemoteAccount(payable(newAccountAddress)).initialize(address(this));
+        RemoteAccount(payable(newAccountAddress)).initialize(address(this), principalAccount);
 
         emit RemoteAccountCreated(newAccountAddress, principalAccount);
     }

--- a/packages/axelar-local-dev-cosmos/src/contracts/design.md
+++ b/packages/axelar-local-dev-cosmos/src/contracts/design.md
@@ -212,6 +212,7 @@ graph TB
     subgraph IRemoteAccount
         IRemoteAccount_executeCalls[executeCalls]
         %% events
+        Initialized@{shape: flag}
         Received@{shape: flag}
         ContractCallSuccess@{shape: flag}
     end
@@ -245,6 +246,7 @@ graph TB
     CTOR -->|calls| _disableInitializers
     initialize -->|modifier| initializer
     initialize -->|sets| factory_ref
+    initialize -->|"emit"| Initialized
     executeCalls -->|"[1]"| AUTH_CHECK
     executeCalls -->|"[2] value > 0"| Received
     executeCalls -->|"[3] loops"| CALL
@@ -263,7 +265,7 @@ graph TB
 
 **Key Components**:
 
-- **initialize**: One-time factory initialization for clone instances
+- **initialize**: One-time factory initialization for clone instances, emits `Initialized` with factory address and principal account
 - **receive**: Accepts native token transfers and emits `Received`
 - **executeCalls**: Calls `factory.checkAuthorizedRouter(msg.sender)`, then atomically executes array of contract calls with per-call reporting
 
@@ -341,7 +343,7 @@ graph TB
 
     _createRemoteAccount -->|calls| cloneDeterministic
     cloneDeterministic -->|"CREATE2"| RAn
-    _createRemoteAccount -->|"initialize(factory)"| RAn
+    _createRemoteAccount -->|"initialize(factory, principalAccount)"| RAn
     _createRemoteAccount -->|"emit"| RemoteAccountCreated
 
     getRemoteAccountAddress -->|calls| _getRemoteAccountAddress
@@ -680,7 +682,7 @@ sequenceDiagram
                 RAF->>RAF: verify address
             else
                 RAF->>RA: cloneDeterministic
-                RAF->>RA: initialize(factory)
+                RAF->>RA: initialize(factory, principalAccount)
             end
         else processRemoteAccountExecuteInstruction
             Note over PR,RA: provide account
@@ -689,7 +691,7 @@ sequenceDiagram
                 RAF->>RAF: verify address
             else
                 RAF->>RA: cloneDeterministic
-                RAF->>RA: initialize(factory)
+                RAF->>RA: initialize(factory, principalAccount)
             end
 
             Note over PR,RA: make calls

--- a/packages/axelar-local-dev-cosmos/src/contracts/interfaces/IRemoteAccount.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/interfaces/IRemoteAccount.sol
@@ -23,6 +23,8 @@ struct ContractCall {
 }
 
 interface IRemoteAccount {
+    event Initialized(address indexed factory, string principalAccount);
+
     event Received(address indexed sender, uint256 amount);
 
     event ContractCallSuccess(


### PR DESCRIPTION
- Add an `Initialized(address indexed factory, string principalAccount)` event to `IRemoteAccount`, emitted during `initialize()`, so the principal is directly discoverable from the RemoteAccount's own logs.

[Slack thread](https://agoricopco.slack.com/archives/C08U1L00F0B/p1774473678847599?thread_ts=1774469448.862719&cid=C08U1L00F0B)