### PR TITLE
 Fix OOG detection for nested calls

### DIFF
--- a/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountMulticall.spec.ts
+++ b/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountMulticall.spec.ts
@@ -177,15 +177,12 @@ describe('RemoteAccountAxelarRouter - RemoteAccountMulticall', () => {
         const multiCalls: ContractCall[] = [multicallContract.alwaysReverts()];
 
         const receipt = await route(portfolioLCA).doRemoteAccountExecute({ multiCalls });
-        const errorEvent = receipt.expectOperationFailure();
-        const RemoteAccount = await ethers.getContractFactory('RemoteAccount');
-        const decoded = RemoteAccount.interface.parseError(errorEvent.args.reason);
-        expect(decoded?.name).to.equal('ContractCallFailed');
-        expect(decoded?.args.target).to.equal(multiCalls[0].target);
-        expect(decoded?.args.selector).to.equal(multiCalls[0].data.slice(0, 10));
-        expect(decoded?.args.callIndex).to.equal(0);
+        const decoded = receipt.expectContractCallFailed();
+        expect(decoded.args.target).to.equal(multiCalls[0].target);
+        expect(decoded.args.selector).to.equal(multiCalls[0].data.slice(0, 10));
+        expect(decoded.args.callIndex).to.equal(0);
         const error = new Error('Synthetic call failure');
-        Object.assign(error, { data: decoded?.args.reason });
+        Object.assign(error, { data: decoded.args.reason });
         await expect(Promise.reject(error)).to.be.revertedWith('Multicall: intentional revert');
     });
 
@@ -233,13 +230,10 @@ describe('RemoteAccountAxelarRouter - RemoteAccountMulticall', () => {
         ];
 
         const receipt = await route(portfolioLCA).doRemoteAccountExecute({ multiCalls });
-        const errorEvent = receipt.expectOperationFailure();
-        const RemoteAccount = await ethers.getContractFactory('RemoteAccount');
-        const decoded = RemoteAccount.interface.parseError(errorEvent.args.reason);
-        expect(decoded?.name).to.equal('ContractCallFailed');
-        expect(decoded?.args.callIndex).to.equal(0);
+        const decoded = receipt.expectContractCallFailed();
+        expect(decoded.args.callIndex).to.equal(0);
         // Empty reason because the subcall ran out of gas
-        expect(decoded?.args.reason).to.equal('0x');
+        expect(decoded.args.reason).to.equal('0x');
     });
 
     it('should send value to a payable method', async () => {

--- a/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountMulticall.spec.ts
+++ b/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountMulticall.spec.ts
@@ -174,16 +174,20 @@ describe('RemoteAccountAxelarRouter - RemoteAccountMulticall', () => {
     });
 
     it('should emit failure when multicall reverts', async () => {
-        const multiCalls: ContractCall[] = [multicallContract.alwaysReverts()];
+        const revertMessage = 'Multicall: intentional revert';
+        const multiCalls: ContractCall[] = [
+            multicallContract.setValue(0n),
+            multicallContract.revertWith(revertMessage),
+        ];
 
         const receipt = await route(portfolioLCA).doRemoteAccountExecute({ multiCalls });
         const decoded = receipt.expectContractCallFailed();
-        expect(decoded.args.target).to.equal(multiCalls[0].target);
-        expect(decoded.args.selector).to.equal(multiCalls[0].data.slice(0, 10));
-        expect(decoded.args.callIndex).to.equal(0);
+        expect(decoded.args.target).to.equal(multiCalls[1].target);
+        expect(decoded.args.selector).to.equal(multiCalls[1].data.slice(0, 10));
+        expect(decoded.args.callIndex).to.equal(1);
         const error = new Error('Synthetic call failure');
         Object.assign(error, { data: decoded.args.reason });
-        await expect(Promise.reject(error)).to.be.revertedWith('Multicall: intentional revert');
+        await expect(Promise.reject(error)).to.be.revertedWith(revertMessage);
     });
 
     it('should revert all calls when second call in batch fails', async () => {
@@ -197,7 +201,7 @@ describe('RemoteAccountAxelarRouter - RemoteAccountMulticall', () => {
         // Batch: first call sets value to 999, second call reverts
         const multiCalls: ContractCall[] = [
             multicallContract.setValue(999n),
-            multicallContract.alwaysReverts(),
+            multicallContract.revertWith('some error'),
         ];
 
         const receipt = await route(portfolioLCA).doRemoteAccountExecute({ multiCalls });

--- a/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountRouter.spec.ts
+++ b/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountRouter.spec.ts
@@ -228,7 +228,7 @@ describe('RemoteAccountAxelarRouter - RouterBehavior', () => {
         receipt.expectOperationFailure();
     });
 
-    it.skip('should revert with SubcallOutOfGas when nested subcall runs out of gas', async () => {
+    it('should revert with SubcallOutOfGas when nested subcall runs out of gas', async () => {
         const lca = 'agoric1nestedoog1234567890abcdefghijklmn';
 
         // Step 1: Pre-create the account so factory.provideRemoteAccount is cheap (verify-only)

--- a/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountRouter.spec.ts
+++ b/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountRouter.spec.ts
@@ -266,6 +266,53 @@ describe('RemoteAccountAxelarRouter - RouterBehavior', () => {
         await expect(receipt).to.be.revertedWithCustomError(router, 'SubcallOutOfGas');
     });
 
+    it('should emit error result when nested subcall fails with reason and low gas', async () => {
+        const lca = 'agoric1nestedfail1234567890abcdefghijklmn';
+        const heavyCall: ContractCall = mc.burnGas(10000n);
+
+        // Step 1: Pre-create the account so factory.provideRemoteAccount is cheap (verify-only)
+        const setupReceipt = await route(lca).doRemoteAccountExecute({ multiCalls: [] });
+        setupReceipt.expectOperationSuccess();
+
+        // Step 2: Build a multicall with burnGas and a simple call to estimate
+        // the gas usage using a real transaction since gas estimation is not precise
+        // enough.
+        const estimateReceipt = await route(lca).doRemoteAccountExecute({
+            multiCalls: [heavyCall, mc.setValue(1n)],
+        });
+        estimateReceipt.expectOperationSuccess();
+        const gasEstimate = estimateReceipt.receipt!.gasUsed;
+
+        const routeWithEstimatedGas = route(lca, {
+            async doExecute(commandId, sourceChain, sourceAddress, payload) {
+                return this.execute(commandId, sourceChain, sourceAddress, payload, {
+                    // Give 10% extra gas so the 63/64ths forwarded avoid OOG in burnGas
+                    // While staying under the 85% low gas heuristics.
+                    gasLimit: (gasEstimate * 11n) / 10n,
+                });
+            },
+        });
+
+        // Step 3: Execute with sufficient gas but placing an empty revert after
+        // burnGas, establishing a baseline for triggering the OOG heuristic.
+        const receiptOOG = await routeWithEstimatedGas.doRemoteAccountExecute({
+            multiCalls: [heavyCall, mc.revertWith('')],
+        });
+        await expect(receiptOOG).to.be.revertedWithCustomError(router, 'SubcallOutOfGas');
+
+        // Step 4: Execute with the same gas but a non-empty revert reason, which
+        // should fail with ContractCallFailed (not OOG) and include the reason.
+        const revertMessage = 'some error';
+        const receiptFail = await routeWithEstimatedGas.doRemoteAccountExecute({
+            multiCalls: [heavyCall, mc.revertWith(revertMessage)],
+        });
+        const decoded = receiptFail.expectContractCallFailed();
+        expect(decoded.args.callIndex).to.equal(1);
+        const error = new Error('Synthetic call failure');
+        Object.assign(error, { data: decoded.args.reason });
+        await expect(Promise.reject(error)).to.be.revertedWith(revertMessage);
+    });
+
     it('should revert with SubcallOutOfGas when self-call OOGs before nested calls', async () => {
         const lca = 'agoric1subcallooghard12345678901234abcde';
 

--- a/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountRouter.spec.ts
+++ b/packages/axelar-local-dev-cosmos/src/__tests__/RemoteAccountRouter.spec.ts
@@ -15,6 +15,8 @@ describe('RemoteAccountAxelarRouter - RouterBehavior', () => {
     let axelarGatewayMock: Contract;
     let factory: Contract, router: Contract, permit2Mock: Contract;
     let multicallTarget: Contract;
+    const mcContract = makeEvmContract(multicallAbi);
+    let mc: ReturnType<typeof contractWithCallMetadata<typeof mcContract>>;
 
     const abiCoder = new ethers.AbiCoder();
 
@@ -84,6 +86,11 @@ describe('RemoteAccountAxelarRouter - RouterBehavior', () => {
 
         const MulticallFactory = await ethers.getContractFactory('Multicall');
         multicallTarget = await MulticallFactory.deploy();
+
+        mc = contractWithCallMetadata(
+            mcContract,
+            multicallTarget.target.toString() as `0x${string}`,
+        );
     });
 
     it('should reject invalid source chain', async () => {
@@ -221,49 +228,7 @@ describe('RemoteAccountAxelarRouter - RouterBehavior', () => {
         receipt.expectOperationFailure();
     });
 
-    it('should revert with SubcallOutOfGas when nested subcall runs out of gas', async () => {
-        const lca = 'agoric1oogtest12345678901234567890abcde';
-
-        // Step 1: Create the account so factory.provideRemoteAccountis cheap (verify-only)
-        const setupReceipt = await route(lca).doRemoteAccountExecute({ multiCalls: [] });
-        setupReceipt.expectOperationSuccess();
-
-        // Step 2: Build a heavy multicall — 100 SSTORE calls to a Multicall target.
-        // This makes the self-call body expensive, ensuring it runs out of gas
-        // when the transaction gas limit is constrained.
-        const mc = contractWithCallMetadata(
-            makeEvmContract(multicallAbi),
-            multicallTarget.target.toString() as `0x${string}`,
-        );
-        const heavyCalls: ContractCall[] = Array.from({ length: 100 }, (_, i) =>
-            mc.setValue(BigInt(i)),
-        );
-
-        const receipt = await route(lca, {
-            async doExecute(commandId, sourceChain, sourceAddress, payload) {
-                // Estimate the gas needed for a successful execution of the heavy multicall
-                const gasEstimate = await this.execute.estimateGas(
-                    commandId,
-                    sourceChain,
-                    sourceAddress,
-                    payload,
-                );
-
-                // Provide 55% of the estimate — the outer _execute has enough gas to complete,
-                // but the self-call's forwarded 63/64ths is insufficient for the 100 SSTORE calls.
-                // The self-call OOGs and returns empty revert data. The router emits
-                // OperationResult with success=false so observers can detect the failure.
-                // Note: The SubcallOutOfGas heuristic does not fire here
-                return this.execute(commandId, sourceChain, sourceAddress, payload, {
-                    gasLimit: (gasEstimate * 55n) / 100n,
-                });
-            },
-        }).doRemoteAccountExecute({ multiCalls: heavyCalls });
-
-        expect(receipt).to.be.revertedWithCustomError(router, 'SubcallOutOfGas');
-    });
-
-    it('should revert with SubcallOutOfGas when a single nested call OOGs inside the target contract', async () => {
+    it.skip('should revert with SubcallOutOfGas when nested subcall runs out of gas', async () => {
         const lca = 'agoric1nestedoog1234567890abcdefghijklmn';
 
         // Step 1: Pre-create the account so factory.provideRemoteAccount is cheap (verify-only)
@@ -274,10 +239,6 @@ describe('RemoteAccountAxelarRouter - RouterBehavior', () => {
         // is expensive inside the target contract.
         // RemoteAccount.executeCalls only iterates once, so the OOG must happen
         // inside the Multicall.burnGas call itself, not in RemoteAccount's loop.
-        const mc = contractWithCallMetadata(
-            makeEvmContract(multicallAbi),
-            multicallTarget.target.toString() as `0x${string}`,
-        );
         const heavyCalls: ContractCall[] = [mc.burnGas(500n)];
 
         const receipt = await route(lca, {
@@ -289,7 +250,7 @@ describe('RemoteAccountAxelarRouter - RouterBehavior', () => {
                     payload,
                 );
 
-                // Provide 55% of the estimate. The router and RemoteAccount frames
+                // Provide 75% of the estimate. The router and RemoteAccount frames
                 // have enough gas to run, but the single burnGas(500) call inside
                 // the target contract exhausts the remaining forwarded gas.
                 // RemoteAccount catches the failed call and reverts with
@@ -297,18 +258,18 @@ describe('RemoteAccountAxelarRouter - RouterBehavior', () => {
                 // router's OOG heuristic detects (Branch 2: ContractCallFailed
                 // with empty reason).
                 return this.execute(commandId, sourceChain, sourceAddress, payload, {
-                    gasLimit: (gasEstimate * 55n) / 100n,
+                    gasLimit: (gasEstimate * 75n) / 100n,
                 });
             },
         }).doRemoteAccountExecute({ multiCalls: heavyCalls });
 
-        expect(receipt).to.be.revertedWithCustomError(router, 'SubcallOutOfGas');
+        await expect(receipt).to.be.revertedWithCustomError(router, 'SubcallOutOfGas');
     });
 
     it('should revert with SubcallOutOfGas when self-call OOGs before nested calls', async () => {
         const lca = 'agoric1subcallooghard12345678901234abcde';
 
-        // Step 1: Pre-create the account so factory.provideRemoteAccountfollows the cheap
+        // Step 1: Pre-create the account so factory.provideRemoteAccount follows the cheap
         // verify path on subsequent calls.
         const setupReceipt = await route(lca).doRemoteAccountExecute({ multiCalls: [] });
         setupReceipt.expectOperationSuccess();
@@ -318,10 +279,6 @@ describe('RemoteAccountAxelarRouter - RouterBehavior', () => {
         // validates all dynamic offsets and lengths at function entry, BEFORE any
         // user code or external calls run. This shifts the gas bottleneck into
         // the self-call, enabling the SubcallOutOfGas heuristic to fire.
-        const mc = contractWithCallMetadata(
-            makeEvmContract(multicallAbi),
-            multicallTarget.target.toString() as `0x${string}`,
-        );
         const heavyCalls: ContractCall[] = Array.from({ length: 500 }, (_, i) =>
             mc.setValue(BigInt(i)),
         );
@@ -348,7 +305,7 @@ describe('RemoteAccountAxelarRouter - RouterBehavior', () => {
             },
         }).doRemoteAccountExecute({ multiCalls: heavyCalls });
 
-        expect(receipt).to.be.revertedWithCustomError(router, 'SubcallOutOfGas');
+        await expect(receipt).to.be.revertedWithCustomError(router, 'SubcallOutOfGas');
     });
 
     it('should reject direct external call to processRemoteAccountExecuteInstruction', async () => {

--- a/packages/axelar-local-dev-cosmos/src/__tests__/contracts/Multicall.sol
+++ b/packages/axelar-local-dev-cosmos/src/__tests__/contracts/Multicall.sol
@@ -21,9 +21,13 @@ contract Multicall {
     function getValue() public view returns (uint256) {
         return value;
     }
+
     // Intended only for use in testing.
-    function alwaysReverts() public pure {
-        revert('Multicall: intentional revert');
+    function revertWith(string calldata message) public pure {
+        if (bytes(message).length == 0) {
+            revert();
+        }
+        revert(message);
     }
 
     // Intended only for use in testing.

--- a/packages/axelar-local-dev-cosmos/src/__tests__/interfaces/multicall.ts
+++ b/packages/axelar-local-dev-cosmos/src/__tests__/interfaces/multicall.ts
@@ -16,11 +16,11 @@ export const multicallAbi = [
         stateMutability: 'nonpayable',
     },
     {
-        name: 'alwaysReverts',
+        name: 'revertWith',
         type: 'function',
-        inputs: [],
+        inputs: [{ name: 'message', type: 'string' }],
         outputs: [],
-        stateMutability: 'nonpayable',
+        stateMutability: 'pure',
     },
     {
         name: 'burnGas',

--- a/packages/axelar-local-dev-cosmos/src/__tests__/lib/utils.ts
+++ b/packages/axelar-local-dev-cosmos/src/__tests__/lib/utils.ts
@@ -8,13 +8,15 @@ import {
 } from 'viem';
 import { expect, use as chaiUse } from 'chai';
 import { ethers, network } from 'hardhat';
-import { Contract, Interface, TransactionReceipt, TransactionResponse } from 'ethers';
+import type { AbiCoder, Contract, TransactionReceipt, TransactionResponse } from 'ethers';
+import { Interface } from 'ethers';
 
 import {
     remoteAccountAxelarRouterABI,
     RouterInstruction,
     RouterOperationPayload,
     SupportedOperations,
+    remoteAccountABI,
 } from '../../interfaces/router';
 import { gmpRouterContract, padTxId, predictRemoteAccountAddress } from '../../utils/router';
 
@@ -231,6 +233,8 @@ const nextTxId = () => {
     return txId;
 };
 
+const remoteAccountInterface = new Interface(remoteAccountABI);
+
 export type ParsedLog = { name: string; args: Record<string, any> };
 const parseLogs = (
     receipt: TransactionReceipt | null,
@@ -292,6 +296,17 @@ const makeReceiptHelper = ({
         return event!;
     };
 
+    const parseOperationError = (contractInterface: Interface = router.interface) => {
+        const event = expectOperationFailure();
+        return contractInterface.parseError(event.args.reason);
+    };
+
+    const expectContractCallFailed = () => {
+        const error = parseOperationError(remoteAccountInterface);
+        expect(error?.name).to.equal('ContractCallFailed');
+        return error!;
+    };
+
     return {
         receipt,
         error,
@@ -306,10 +321,8 @@ const makeReceiptHelper = ({
         getOperationResult,
         expectOperationSuccess,
         expectOperationFailure,
-        parseOperationError(contractInterface: Interface = router.interface) {
-            const event = expectOperationFailure();
-            return contractInterface.parseError(event.args.reason);
-        },
+        expectContractCallFailed,
+        parseOperationError,
     };
 };
 
@@ -357,7 +370,7 @@ export const routed = (
         owner: { address: string; signMessage: (msg: Uint8Array) => Promise<string> };
         portfolioContractAccount: string;
         AxelarGateway: Contract;
-        abiCoder: { encode: (types: string[], values: unknown[]) => string };
+        abiCoder: AbiCoder;
     },
 ) => {
     return (

--- a/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountAxelarRouter.sol
+++ b/packages/axelar-local-dev-cosmos/src/contracts/RemoteAccountAxelarRouter.sol
@@ -172,25 +172,65 @@ contract RemoteAccountAxelarRouter is AxelarExecutable, IRemoteAccountRouter {
         // which are better than quickly treating it as a failed operation,
         // requiring the end-user to take action and sign a new intent.
         if (!success && gasAfter <= (gasBefore / 7)) {
-            if (result.length == 0) {
+            uint256 resultLength = result.length;
+            if (resultLength == 0) {
                 // The call likely ran out of gas without RemoteAccount interception
                 revert SubcallOutOfGas();
             }
 
-            if (bytes4(result) == IRemoteAccount.ContractCallFailed.selector) {
-                // Prepend 28 bytes of zeros to 'complete' the custom error selector into a 32-byte word.
-                // This allows abi.decode to treat the selector as the first argument.
-                bytes memory paddedData = abi.encodePacked(new bytes(28), result);
+            // This failure came with a result from which we might be able to
+            // read a reason. Try to decode it as a ContractCallFailed error:
+            // | offset | description        | size (bytes) |
+            // |-------:|--------------------|--------------|
+            // |      0 | selector           |  4
+            // |        | <start of params>
+            // |      4 | targetAddress      | 32
+            // |     36 | callSelector       | 32
+            // |     68 | callIndex          | 32
+            // |    100 | offset to reason   | 32
+            // |        | <start of dynamic param encodings>
+            // |        | <start of enc(reason)>
+            // |    132 | reason byte length | 32
+            // |    164 | reason contents    | <variable>
+            if (
+                bytes4(result) == IRemoteAccount.ContractCallFailed.selector && resultLength >= 164
+            ) {
+                // reasonLengthPosition is the offset of enc(reason) relative to
+                // the start of result (including the 32-byte length slot).
+                uint256 reasonLengthPosition;
+                assembly ('memory-safe') {
+                    reasonLengthPosition := add(
+                        // The position of offset-to-reason in result is 0x20
+                        // (size of result's initial 32-byte length slot) + 100
+                        // = 0x84. Per above, this value is expected to be
+                        // 132 - 4 = 0x80.
+                        mload(add(result, 0x84)),
+                        // The *value* of offset-to-reason is relative to
+                        // start-of-params and must therefore be increased to
+                        // account for result's length slot and the 4-byte
+                        // selector.
+                        0x24
+                    )
+                }
 
-                // Now we decode including the error selector as the first argument.
-                (, , , , bytes memory reason) = abi.decode(
-                    paddedData,
-                    (bytes4, address, bytes4, uint224, bytes)
-                );
+                // Check if result is long enough to contain a uint256 at
+                // reasonLengthPosition. This is logically
+                // `sizeof result >= reasonLengthPosition + 32`, but
+                // `result.length` excludes the 32-byte length slot so the
+                // resulting `32 + result.length >= reasonLengthPosition + 32`
+                // can be reduced to eliminate addition on both sides.
+                if (resultLength >= reasonLengthPosition) {
+                    uint256 reasonLength;
+                    assembly ('memory-safe') {
+                        reasonLength := mload(add(result, reasonLengthPosition))
+                    }
 
-                if (reason.length == 0) {
-                    // The call made by RemoteAccount likely ran out of gas
-                    revert SubcallOutOfGas();
+                    // If we just read a length of 0, assume that the
+                    // corresponding empty reason indicates that the call made
+                    // by RemoteAccount ran out of gas.
+                    if (reasonLength == 0) {
+                        revert SubcallOutOfGas();
+                    }
                 }
             }
         }

--- a/packages/axelar-local-dev-cosmos/src/interfaces/router.ts
+++ b/packages/axelar-local-dev-cosmos/src/interfaces/router.ts
@@ -279,6 +279,16 @@ export const remoteAccountABI = [
         outputs: [],
         stateMutability: 'nonpayable',
     },
+    {
+        type: 'error',
+        name: 'ContractCallFailed',
+        inputs: [
+            { name: 'target', type: 'address' },
+            { name: 'selector', type: 'bytes4' },
+            { name: 'callIndex', type: 'uint32' },
+            { name: 'reason', type: 'bytes' },
+        ],
+    },
 ] as const satisfies Abi;
 
 /**


### PR DESCRIPTION
Closes: https://linear.app/agoric/issue/AGO-540/address-oog-finding

The router has a logic flaw in the OOG detection logic which would result in a reverted transaction with an empty reason (decoding error) when the tx used 85%+ of its gas (aka we triggered the first out-of-gas heuristics condition), and a RemoteAccount multicall failed. This would happen when the nested failure is either an empty reason (suspected out-of-gas), or not (custom error or message).

While this flaw doesn't have any operational impact, it could end up delaying the resolution of failed multicalls (reverting instead of emitting operation error event), or hide OOG diagnostics in traces.

# Testing considerations

An existing test was meant to test this case but it had 2 flaws:
- It used the wrong gas amount, triggering the non-nested case
- The assertion was not `await`ed, resulting in the diagnostics to be missed

This PR fixes the test and removes a duplicate test, as well as doing some drive-by cleanup.

It also adds a new test to explicitly verify the ContractCallFailed path in the OOG heuristics.

# Update considerations

Consumers would need to deploy and switch to the fixed router to benefit from this fix. The factory and remote account themselves are not affected.