### PR TITLE
chore(ci): Update GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/agoric-integration.yml
+++ b/.github/workflows/agoric-integration.yml
@@ -19,12 +19,15 @@ jobs:
 
     steps:
       - name: Checkout this repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Use Node 20
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
+          # keep setup-node v4 behavior: packageManager is yarn but there is
+          # no yarn.lock, so automatic caching would fail
+          package-manager-cache: false
 
       - name: Install dependencies
         run: npm install && cd integration && yarn install

--- a/.github/workflows/deploy-contracts.yml
+++ b/.github/workflows/deploy-contracts.yml
@@ -65,15 +65,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cache node_modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -10,18 +10,26 @@ jobs:
     name: "Publish to NPM"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
         with:
           node-version: "16.x"
           registry-url: "https://registry.npmjs.org"
+          # keep setup-node v4 behavior: packageManager is yarn but there is
+          # no yarn.lock, so automatic caching would fail
+          package-manager-cache: false
+
       - name: Cache node_modules
-        uses: actions/cache@v2
+        uses: actions/cache@v5
         with:
           path: node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+
       - run: npm ci
+
       - run: npm run build
+
       - run: npm run publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/test-aptos.yml
+++ b/.github/workflows/test-aptos.yml
@@ -20,18 +20,18 @@ jobs:
         run: rm -rf target aptos-cli-1.0.4-Ubuntu-22.04-x86_64.zip
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 18
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
 
       - name: Cache node_modules
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/test-cosmos.yml
+++ b/.github/workflows/test-cosmos.yml
@@ -13,15 +13,15 @@ jobs:
         node-version: ["18.x"]
     steps:
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cache node_modules
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/test-evm.yml
+++ b/.github/workflows/test-evm.yml
@@ -13,15 +13,15 @@ jobs:
         node-version: ["18.x", "20.x"]
     steps:
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cache node_modules
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/test-multiversex.yml
+++ b/.github/workflows/test-multiversex.yml
@@ -19,12 +19,12 @@ jobs:
           - "9200:9200"
     steps:
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 18
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download and Install Multiversx Binary
         run: |
@@ -39,7 +39,7 @@ jobs:
         uses: foundry-rs/foundry-toolchain@v1
 
       - name: Cache node_modules
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/test-sui.yml
+++ b/.github/workflows/test-sui.yml
@@ -24,15 +24,15 @@ jobs:
         run: rm -rf target sui-devnet-v1.7.0-ubuntu-x86_64.tgz
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 18
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cache node_modules
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}


### PR DESCRIPTION
GitHub [deprecated Node.js 20 on Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/); this repo also still referenced majors on the long-removed node12/node16 runtimes. All are bumped to the lowest major that declares `node24` natively:

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v3, v4 | v5 |
| `actions/setup-node` | v3, v4 | v5 |
| `actions/cache` | v2, v3, v4 | v5 |

Unchanged: `foundry-rs/foundry-toolchain@v1` — its moving `v1` tag already resolves to a node24 build.

## Behavior-preserving guard

`setup-node@v5` auto-enables dependency caching when `package.json` declares a `packageManager`. This repo declares `packageManager: yarn@1.22.22` but only ships a `package-lock.json` (no `yarn.lock`), so auto-caching would fail the job wherever `package.json` is on disk when setup-node runs. The two workflows where checkout precedes setup-node (`agoric-integration.yml`, `publish-to-npm.yml`) therefore set `package-manager-cache: false`, preserving the exact v4 behavior. The other workflows run setup-node *before* checkout, so auto-detection finds nothing and stays inert.
